### PR TITLE
Add authfile for skopeo login

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install Python 2.6
         run: sudo apt-get install -y python2.6 python2.6-dev
       - name: Install pip
-        run: curl https://bootstrap.pypa.io/2.6/get-pip.py -o get-pip.py && sudo python2.6 get-pip.py
+        run: curl https://bootstrap.pypa.io/pip/2.6/get-pip.py -o get-pip.py && sudo python2.6 get-pip.py
       - name: Install Python dependencies
         run: sudo pip install -r requirements-test-py26.txt -r requirements-py26.txt && sudo pip install .
       - name: Run tests

--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -44,7 +44,9 @@ class Executor(object):
             )
         LOG.info("Logging in to Quay with provided credentials")
 
-        cmd_login = "skopeo login -u {0} --password-stdin quay.io".format(username)
+        cmd_login = (
+            "skopeo login --authfile $HOME/.docker/config.json -u {0} --password-stdin quay.io"
+        ).format(username)
         out, err = self._run_cmd(cmd_login, stdin=password)
 
         if "Login Succeeded" in out:

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -234,7 +234,9 @@ def test_skopeo_login_success(mock_run_cmd):
     assert mock_run_cmd.call_args_list == [
         mock.call("skopeo login --get-login quay.io", tolerate_err=True),
         mock.call(
-            "skopeo login -u quay_user --password-stdin quay.io", stdin="quay_token"
+            "skopeo login --authfile $HOME/.docker/config.json -u quay_user "
+            "--password-stdin quay.io",
+            stdin="quay_token",
         ),
     ]
 


### PR DESCRIPTION
Default authfile is ${XDG_RUNTIME_DIR}/containers/auth.json which is removed
when SSH session of a remote skopeo login terminates. $HOME/.docker/config.json
won't be removed by system logout and is checked when authorization state isn't
found in the default authfile.