### PR TITLE
Implement entrypoints for pub IIB methods

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -63,7 +63,7 @@ def verify_target_settings(target_settings):
 
 
 def task_iib_add_bundles(
-    bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+    bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
 ):
     """
     Perform all the necessary actions for the 'PushAddIIBBundles' entrypoint.
@@ -77,8 +77,8 @@ def task_iib_add_bundles(
             Index image to add the bundles to.
         deprecation_list ([str]):
             Bundles to deprecate in the index image.
-        signing_key (str):
-            Signing key to be used.
+        signing_keys ([str]):
+            Signing keys to be used.
         hub (HubProxy):
             Instance of XMLRPC pub-hub proxy.
         task_id (str):
@@ -116,7 +116,7 @@ def task_iib_add_bundles(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(signing_key, intermediate_index_image, tag)
+    sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, tag)
 
     # Push image to Quay
     # NOTE: tagging doesn't use intermediate index image, because we want the most up-to-date
@@ -127,7 +127,7 @@ def task_iib_add_bundles(
 
 
 def task_iib_remove_operators(
-    operators, archs, index_image, signing_key, hub, task_id, target_settings
+    operators, archs, index_image, signing_keys, hub, task_id, target_settings
 ):
     """
     Perform all the necessary actions for the 'PushRemoveIIBOperators' entrypoint.
@@ -139,8 +139,8 @@ def task_iib_remove_operators(
             Architectures to build the index image for.
         index_image (str):
             Index image to remove the operators from.
-        signing_key (str):
-            Signing key to be used.
+        signing_keys (str):
+            Signing keys to be used.
         hub (HubProxy):
             Instance of XMLRPC pub-hub proxy.
         task_id (str):
@@ -177,7 +177,7 @@ def task_iib_remove_operators(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(signing_key, intermediate_index_image, tag)
+    sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, tag)
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
@@ -186,7 +186,7 @@ def task_iib_remove_operators(
 
 
 def task_iib_build_from_scratch(
-    bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
 ):
     """
     Perform all the necessary actions for the 'PushIIBBuildFromScratch' entrypoint.
@@ -198,8 +198,8 @@ def task_iib_build_from_scratch(
             Architectures to build the index image for.
         index_image_tag (str):
             Tag to be applied to the new index image.
-        signing_key (str):
-            Signing key to be used.
+        signing_keys (str):
+            Signing keys to be used.
         hub (HubProxy):
             Instance of XMLRPC pub-hub proxy.
         task_id (str):
@@ -235,7 +235,7 @@ def task_iib_build_from_scratch(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(signing_key, intermediate_index_image, index_image_tag)
+    sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, index_image_tag)
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
@@ -244,27 +244,27 @@ def task_iib_build_from_scratch(
 
 
 def iib_add_entrypoint(
-    bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+    bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
 ):
     """Entry point for use in another python code."""
     task_iib_add_bundles(
-        bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+        bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
     )
 
 
 def iib_remove_entrypoint(
-    operators, archs, index_image, signing_key, hub, task_id, target_settings
+    operators, archs, index_image, signing_keys, hub, task_id, target_settings
 ):
     """Entry point for use in another python code."""
     task_iib_remove_operators(
-        operators, archs, index_image, signing_key, hub, task_id, target_settings
+        operators, archs, index_image, signing_keys, hub, task_id, target_settings
     )
 
 
 def iib_from_scratch_entrypoint(
-    bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
 ):
     """Entry point for use in another python code."""
     task_iib_build_from_scratch(
-        bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+        bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
     )

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -1,0 +1,245 @@
+import logging
+
+from .container_image_pusher import ContainerImagePusher
+from .exceptions import InvalidTargetSettings
+from .operator_pusher import OperatorPusher
+from .signature_handler import OperatorSignatureHandler
+from .utils.misc import get_internal_container_repo_name
+
+LOG = logging.getLogger("PubLogger")
+LOG.setLevel(logging.INFO)
+
+
+def verify_target_settings(target_settings):
+    """
+    Verify the presence and validity of target settings.
+
+    Args:
+        target_settings (dict):
+            Dictionary containing settings necessary for performing the operation.
+    """
+    LOG.info("Verifying the necessary target settings")
+
+    required_settings = [
+        "quay_user",
+        "quay_password",
+        "quay_api_token",
+        "pyxis_server",
+        "quay_namespace",
+        "iib_krb_principal",
+        "iib_index_image",
+        "quay_operator_repository",
+        "ssh_remote_host",
+        "ssh_user",
+        "ssh_password",
+        "docker_settings",
+    ]
+
+    for setting in required_settings:
+        if setting not in target_settings:
+            raise InvalidTargetSettings(
+                "'{0}' must be present in the target settings.".format(setting)
+            )
+
+    required_docker_settings = ["umb_urls", "docker_reference_registry"]
+    for setting in required_docker_settings:
+        if setting not in target_settings["docker_settings"]:
+            raise InvalidTargetSettings(
+                "'{0}' must be present in the docker settings.".format(setting)
+            )
+    if (
+        "iib_overwrite_from_index_token" in target_settings
+        and "iib_overwrite_from_index" not in target_settings
+    ) or (
+        "iib_overwrite_from_index_token" not in target_settings
+        and "iib_overwrite_from_index" in target_settings
+    ):
+        msg = (
+            "Either both or neither of 'iib_overwrite_from_index' and "
+            "'iib_overwrite_from_index_token' should be specified in target settings."
+        )
+        LOG.error(msg)
+        raise InvalidTargetSettings(msg)
+
+
+def task_iib_add_bundles(
+    bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+):
+    """
+    Perform all the necessary actions for the 'PushAddIIBBundles' entrypoint.
+
+    Args:
+        bundles ([str]):
+            Bundles to add to the index image.
+        archs ([str]):
+            Architectures to build the index image for.
+        index_image (str):
+            Index image to add the bundles to.
+        deprecation_list ([str]):
+            Bundles to deprecate in the index image.
+        signing_key (str):
+            Signing key to be used.
+        hub (HubProxy):
+            Instance of XMLRPC pub-hub proxy.
+        task_id (str):
+            ID of the pub task.
+        target_settings (dict):
+            Dictionary containing settings necessary for performing the operation.
+    """
+    image_schema = "{host}/{namespace}/{repo}"
+    verify_target_settings(target_settings)
+
+    # Build new index image in IIB
+    build_details = OperatorPusher.iib_add_bundles(
+        bundles=bundles,
+        archs=archs,
+        index_image=index_image,
+        deprecation_list=deprecation_list,
+        target_settings=target_settings,
+    )
+
+    # Push image to Quay
+    index_image_repo = image_schema.format(
+        host=target_settings.get("quay_host", "quay.io").rstrip("/"),
+        namespace=target_settings["quay_namespace"],
+        repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
+    )
+    # TODO: how is tag set? Do we derive it from source or destination index image?
+    _, tag = build_details.index_image.split(":", 1)
+    dest_image = "{0}:{1}".format(index_image_repo, tag)
+
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
+
+    # Sign image
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+
+def task_iib_remove_operators(
+    operators, archs, index_image, signing_key, hub, task_id, target_settings
+):
+    """
+    Perform all the necessary actions for the 'PushRemoveIIBOperators' entrypoint.
+
+    Args:
+        operators ([str]):
+            Operators to remove from the index image.
+        arch ([str]):
+            Architectures to build the index image for.
+        index_image (str):
+            Index image to remove the operators from.
+        signing_key (str):
+            Signing key to be used.
+        hub (HubProxy):
+            Instance of XMLRPC pub-hub proxy.
+        task_id (str):
+            ID of the pub task.
+        target_settings (dict):
+            Dictionary containing settings necessary for performing the operation.
+    """
+    image_schema = "{host}/{namespace}/{repo}"
+    verify_target_settings(target_settings)
+
+    # Build new index image in IIB
+    build_details = OperatorPusher.iib_remove_operators(
+        operators=operators,
+        archs=archs,
+        index_image=index_image,
+        target_settings=target_settings,
+    )
+
+    # Push image to Quay
+    index_image_repo = image_schema.format(
+        host=target_settings.get("quay_host", "quay.io").rstrip("/"),
+        namespace=target_settings["quay_namespace"],
+        repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
+    )
+    # TODO: how is tag set? Do we derive it from source or destination index image?
+    _, tag = build_details.index_image.split(":", 1)
+    dest_image = "{0}:{1}".format(index_image_repo, tag)
+
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
+
+    # Sign image
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+
+def task_iib_build_from_scratch(
+    bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+):
+    """
+    Perform all the necessary actions for the 'PushIIBBuildFromScratch' entrypoint.
+
+    Args:
+        bundles ([str]):
+            Bundles to add to the index image.
+        archs ([str]):
+            Architectures to build the index image for.
+        index_image_tag (str):
+            Tag to be applied to the new index image.
+        signing_key (str):
+            Signing key to be used.
+        hub (HubProxy):
+            Instance of XMLRPC pub-hub proxy.
+        task_id (str):
+            ID of the pub task.
+        target_settings (dict):
+            Dictionary containing settings necessary for performing the operation.
+    """
+    image_schema = "{host}/{namespace}/{repo}"
+    verify_target_settings(target_settings)
+
+    # Build new index image in IIB
+    build_details = OperatorPusher.iib_add_bundles(
+        bundles=bundles,
+        archs=archs,
+        target_settings=target_settings,
+    )
+
+    # Push image to Quay
+    index_image_repo = image_schema.format(
+        host=target_settings.get("quay_host", "quay.io").rstrip("/"),
+        namespace=target_settings["quay_namespace"],
+        repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
+    )
+    dest_image = "{0}:{1}".format(index_image_repo, index_image_tag)
+
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
+
+    # Sign image
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+
+def iib_add_entrypoint(
+    bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+):
+    """Entry point for use in another python code."""
+    task_iib_add_bundles(
+        bundles, archs, index_image, deprecation_list, signing_key, hub, task_id, target_settings
+    )
+
+
+def iib_remove_entrypoint(
+    operators, archs, index_image, signing_key, hub, task_id, target_settings
+):
+    """Entry point for use in another python code."""
+    task_iib_remove_operators(
+        operators, archs, index_image, signing_key, hub, task_id, target_settings
+    )
+
+
+def iib_from_scratch_entrypoint(
+    bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+):
+    """Entry point for use in another python code."""
+    task_iib_build_from_scratch(
+        bundles, archs, index_image_tag, signing_key, hub, task_id, target_settings
+    )

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -108,7 +108,7 @@ def task_iib_add_bundles(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+    sig_handler.sign_task_index_image(build_details, signing_key, build_details.index_image)
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
@@ -159,7 +159,7 @@ def task_iib_remove_operators(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+    sig_handler.sign_task_index_image(build_details, signing_key, build_details.index_image)
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
@@ -208,7 +208,9 @@ def task_iib_build_from_scratch(
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
-    sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+    sig_handler.sign_task_index_image(
+        build_details, signing_key, build_details.index_image, tag=index_image_tag
+    )
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -86,7 +86,8 @@ def task_iib_add_bundles(
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
     """
-    image_schema = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
     verify_target_settings(target_settings)
 
     # Build new index image in IIB
@@ -99,19 +100,20 @@ def task_iib_add_bundles(
     )
 
     _, tag = build_details.index_image.split(":", 1)
-    dest_image = image_schema.format(
+    dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag=tag,
     )
-    # TODO: does target_settings["quay_namespace"] point to rh-osbs?
     # Index image used to fetch manifest list. This image will never be overwritten
-    intermediate_index_image = image_schema.format(
+    iib_namespace = build_details.index_image_resolved.split("/")[1]
+    image_digest = build_details.index_image_resolved.split("@")[1]
+    intermediate_index_image = image_schema_digest.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=iib_namespace,
         repo="iib",
-        tag=tag,
+        digest=image_digest,
     )
 
     # Sign image
@@ -148,7 +150,8 @@ def task_iib_remove_operators(
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
     """
-    image_schema = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
     verify_target_settings(target_settings)
 
     # Build new index image in IIB
@@ -160,7 +163,7 @@ def task_iib_remove_operators(
     )
 
     _, tag = build_details.index_image.split(":", 1)
-    dest_image = image_schema.format(
+    dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
@@ -168,11 +171,13 @@ def task_iib_remove_operators(
     )
 
     # Index image used to fetch manifest list. This image will never be overwritten
-    intermediate_index_image = image_schema.format(
+    iib_namespace = build_details.index_image_resolved.split("/")[1]
+    image_digest = build_details.index_image_resolved.split("@")[1]
+    intermediate_index_image = image_schema_digest.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=iib_namespace,
         repo="iib",
-        tag=tag,
+        digest=image_digest,
     )
 
     # Sign image
@@ -207,7 +212,8 @@ def task_iib_build_from_scratch(
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
     """
-    image_schema = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
+    image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
     verify_target_settings(target_settings)
 
     # Build new index image in IIB
@@ -217,7 +223,7 @@ def task_iib_build_from_scratch(
         target_settings=target_settings,
     )
 
-    dest_image = image_schema.format(
+    dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
@@ -226,11 +232,13 @@ def task_iib_build_from_scratch(
 
     _, tag = build_details.index_image.split(":", 1)
     # Index image used to fetch manifest list. This image will never be overwritten
-    intermediate_index_image = image_schema.format(
+    iib_namespace = build_details.index_image_resolved.split("/")[1]
+    image_digest = build_details.index_image_resolved.split("@")[1]
+    intermediate_index_image = image_schema_digest.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=iib_namespace,
         repo="iib",
-        tag=tag,
+        digest=image_digest,
     )
 
     # Sign image

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -98,23 +98,22 @@ def task_iib_add_bundles(
         target_settings=target_settings,
     )
 
-    # Push image to Quay
     index_image_repo = image_schema.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
     )
-    # TODO: how is tag set? Do we derive it from source or destination index image?
     _, tag = build_details.index_image.split(":", 1)
     dest_image = "{0}:{1}".format(index_image_repo, tag)
-
-    ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
-    )
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
     sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+    # Push image to Quay
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
 
 
 def task_iib_remove_operators(
@@ -150,23 +149,22 @@ def task_iib_remove_operators(
         target_settings=target_settings,
     )
 
-    # Push image to Quay
     index_image_repo = image_schema.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
     )
-    # TODO: how is tag set? Do we derive it from source or destination index image?
     _, tag = build_details.index_image.split(":", 1)
     dest_image = "{0}:{1}".format(index_image_repo, tag)
-
-    ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
-    )
 
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
     sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+    # Push image to Quay
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
 
 
 def task_iib_build_from_scratch(
@@ -201,7 +199,6 @@ def task_iib_build_from_scratch(
         target_settings=target_settings,
     )
 
-    # Push image to Quay
     index_image_repo = image_schema.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=target_settings["quay_namespace"],
@@ -209,13 +206,14 @@ def task_iib_build_from_scratch(
     )
     dest_image = "{0}:{1}".format(index_image_repo, index_image_tag)
 
-    ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
-    )
-
     # Sign image
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
     sig_handler.sign_task_index_image(build_details, signing_key, dest_image)
+
+    # Push image to Quay
+    ContainerImagePusher.run_tag_images(
+        build_details.index_image, [dest_image], True, target_settings
+    )
 
 
 def iib_add_entrypoint(

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -400,4 +400,6 @@ class OperatorPusher:
 
             _, tag = build_details.index_image.split(":", 1)
             dest_image = "{0}:{1}".format(index_image_repo, tag)
-            self.run_tag_images(build_details.index_image, [dest_image], True)
+            ContainerImagePusher.run_tag_images(
+                build_details.index_image, [dest_image], True, self.target_settings
+            )

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -251,8 +251,8 @@ class OperatorPusher:
                 Architectures to build for.
             index_image (str):
                 Index image to add the bundles to.
-            deprecation_list ([str]):
-                List of bundles to be deprecated.
+            deprecation_list ([str]|str):
+                List of bundles to be deprecated. Accepts both str (csv) and a list.
             target_settings (dict):
                 Settings used for setting the value of pubtools-iib parameters.
 
@@ -273,8 +273,10 @@ class OperatorPusher:
             for arch in archs:
                 args += ["--arch", arch]
         # inconsistent way of presenting multiple arguments...
-        if deprecation_list:
+        if deprecation_list and isinstance(deprecation_list, str):
             args += ["--deprecation-list", deprecation_list]
+        elif deprecation_list and isinstance(deprecation_list, list):
+            args += ["--deprecation-list", ",".join(deprecation_list)]
 
         return run_entrypoint(
             ("pubtools-iib", "console_scripts", "pubtools-iib-add-bundles"),

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -6,7 +6,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
-from .tag_images import tag_images
+from .container_image_pusher import ContainerImagePusher
 from .utils.misc import (
     run_entrypoint,
     get_internal_container_repo_name,
@@ -206,7 +206,41 @@ class OperatorPusher:
         LOG.info("Deprecation list retrieved successfully")
         return sorted(deprecation_list)
 
-    def iib_add_bundles(self, bundles, archs, ocp_version, deprecation_list=None):
+    @classmethod
+    def pubtools_iib_get_common_args(cls, target_settings):
+        """
+        Create an argument list common for all pubtools-iib operations.
+
+        Target settings are used to set the values of the arguments
+
+        Args:
+            target_settings (dict):
+                Settings used for setting the value of pubtools-iib parameters.
+        Returns (([str]), {str:str}):
+            Tuple of arguments and environment variables to be used when calling pubtools-iib.
+        """
+        args = ["--skip-pulp"]
+
+        args += ["--iib-server", target_settings["iib_server"]]
+        args += ["--iib-krb-principal", target_settings["iib_krb_principal"]]
+
+        if "iib_overwrite_from_index" in target_settings:
+            args += ["--overwrite-from-index"]
+        if "iib_krb_ktfile" in target_settings:
+            args += ["--iib-krb-ktfile", target_settings["iib_krb_ktfile"]]
+
+        env_vars = {}
+        if "iib_overwrite_from_index_token" in target_settings:
+            env_vars["OVERWRITE_FROM_INDEX_TOKEN"] = target_settings[
+                "iib_overwrite_from_index_token"
+            ]
+
+        return (args, env_vars)
+
+    @classmethod
+    def iib_add_bundles(
+        cls, bundles=None, archs=None, index_image=None, deprecation_list=None, target_settings={}
+    ):
         """
         Construct and execute pubtools-iib command to add bundles to index image.
 
@@ -215,46 +249,32 @@ class OperatorPusher:
                 External URLs to bundle images to be added to the index image.
             archs ([str]):
                 Architectures to build for.
-            ocp_version (str):
-                OCP version to add the bundles to. It acts as a tag of the index image.
+            index_image (str):
+                Index image to add the bundles to.
             deprecation_list ([str]):
                 List of bundles to be deprecated.
+            target_settings (dict):
+                Settings used for setting the value of pubtools-iib parameters.
 
         Returns (dict):
             Build details provided by IIB.
         """
         LOG.info(
-            "Requesting IIB to add bundles '{0}' to index image version '{1}'".format(
-                bundles, ocp_version
-            )
+            "Requesting IIB to add bundles '{0}' to index image '{1}'".format(bundles, index_image)
         )
-        args = ["--skip-pulp"]
+        args, env_vars = cls.pubtools_iib_get_common_args(target_settings)
 
-        args += ["--iib-server", self.target_settings["iib_server"]]
-        args += ["--iib-krb-principal", self.target_settings["iib_krb_principal"]]
-
-        if "iib_overwrite_from_index" in self.target_settings:
-            args += ["--overwrite-from-index"]
-        if "iib_krb_ktfile" in self.target_settings:
-            args += ["--iib-krb-ktfile", self.target_settings["iib_krb_ktfile"]]
-
-        index_image = "{image_repo}:{tag}".format(
-            image_repo=self.target_settings["iib_index_image"], tag=ocp_version
-        )
-        args += ["--index-image", index_image]
-        for bundle in bundles:
-            args += ["--bundle", bundle]
-        for arch in archs:
-            args += ["--arch", arch]
+        if index_image:
+            args += ["--index-image", index_image]
+        if bundles:
+            for bundle in bundles:
+                args += ["--bundle", bundle]
+        if archs:
+            for arch in archs:
+                args += ["--arch", arch]
         # inconsistent way of presenting multiple arguments...
         if deprecation_list:
-            args += ["--deprecation-list", ",".join(deprecation_list)]
-
-        env_vars = {}
-        if "iib_overwrite_from_index_token" in self.target_settings:
-            env_vars["OVERWRITE_FROM_INDEX_TOKEN"] = self.target_settings[
-                "iib_overwrite_from_index_token"
-            ]
+            args += ["--deprecation-list", deprecation_list]
 
         return run_entrypoint(
             ("pubtools-iib", "console_scripts", "pubtools-iib-add-bundles"),
@@ -263,40 +283,45 @@ class OperatorPusher:
             env_vars,
         )
 
-    def run_tag_images(self, source_ref, dest_refs, all_arch):
+    @classmethod
+    def iib_remove_operators(cls, operators=None, archs=None, index_image=None, target_settings={}):
         """
-        Prepare the "tag images" entrypoint with all the necessary arguments and run it.
+        Construct and execute pubtools-iib command to remove operators from index image.
 
         Args:
-            source_ref (str):
-                Source image reference.
-            dest_refs ([str]):
-                List of destination references.
-            all_arch (bool):
-                Whether all architectures should be copied.
+            operators ([str]):
+                Operator names to be removed from the index image.
+            archs ([str]):
+                Architectures to build for.
+            ocp_version (str):
+                Index image to remove the operators from.
+            target_settings (dict):
+                Settings used for setting the value of pubtools-iib parameters.
+
+        Returns (dict):
+            Build details provided by IIB.
         """
-        tag_images(
-            source_ref,
-            dest_refs,
-            all_arch=all_arch,
-            quay_user=self.target_settings["quay_user"],
-            quay_password=self.target_settings["quay_password"],
-            remote_exec=True,
-            send_umb_msg=True,
-            ssh_remote_host=self.target_settings["ssh_remote_host"],
-            ssh_username=self.target_settings["ssh_user"],
-            ssh_password=self.target_settings["ssh_password"],
-            umb_urls=self.target_settings["docker_settings"]["umb_urls"],
-            umb_cert=self.target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            # assumption that we'll continue using .pem format
-            umb_client_key=self.target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            umb_ca_cert=self.target_settings["docker_settings"].get(
-                "umb_ca_cert", "/etc/pki/tls/certs/ca-bundle.crt"
-            ),
+        LOG.info(
+            "Requesting IIB to remove operators '{0}' from index image '{1}'".format(
+                operators, index_image
+            )
+        )
+        args, env_vars = cls.pubtools_iib_get_common_args(target_settings)
+
+        if index_image:
+            args += ["--index-image", index_image]
+        if operators:
+            for operator in operators:
+                args += ["--operator", operator]
+        if archs:
+            for arch in archs:
+                args += ["--arch", arch]
+
+        return run_entrypoint(
+            ("pubtools-iib", "console_scripts", "pubtools-iib-remove-operators"),
+            "pubtools-iib-remove-operators",
+            args,
+            env_vars,
         )
 
     @log_step("Build index images")
@@ -304,8 +329,10 @@ class OperatorPusher:
         """
         Perform the 'build' part of the operator workflow.
 
+        This workflow is a part of push-docker operation.
         The workflow can be summarized as:
         - Use Pyxis to parse 'com.redhat.openshift.versions'
+        - Get deprecation list for a given version (list of bundles to be deprecated)
         - Create mapping of which bundles should be pushed to which index image versions
         - Contact IIB to add the bundles to the index images
 
@@ -335,7 +362,16 @@ class OperatorPusher:
             deprecation_list = self.get_deprecation_list(version)
 
             # build index image in IIB
-            build_details = self.iib_add_bundles(bundles, archs, version, deprecation_list)
+            index_image = "{image_repo}:{tag}".format(
+                image_repo=self.target_settings["iib_index_image"], tag=version
+            )
+            build_details = self.iib_add_bundles(
+                bundles=bundles,
+                archs=archs,
+                index_image=index_image,
+                deprecation_list=deprecation_list,
+                target_settings=self.target_settings,
+            )
 
             iib_results[version] = {"iib_result": build_details, "signing_keys": signing_keys}
 

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -97,6 +97,9 @@ class PushDocker:
             "iib_organization",
             "iib_index_image",
             "quay_operator_repository",
+            "ssh_remote_host",
+            "ssh_user",
+            "ssh_password",
             "docker_settings",
         ]
         for setting in required_settings:

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -605,7 +605,7 @@ class OperatorSignatureHandler(SignatureHandler):
             ),
         )
 
-    def sign_task_index_image(self, build_details, signing_key, index_image):
+    def sign_task_index_image(self, build_details, signing_key, index_image, tag=None):
         """
         Perform an alternatve signing workflow used by IIB methods in pub.
 
@@ -618,9 +618,13 @@ class OperatorSignatureHandler(SignatureHandler):
             signing_key (str):
                 Signing key to be used.
             index_image (str):
-                Index image to be signed. Must be specified via tag.
+                Index image to be signed.
+            tag (str|None):
+                Tag of the result index image. If not specified, it's derived from the provided
+                index image.
         """
-        tag = index_image.split(":")[-1]
+        if tag is None:
+            tag = index_image.split(":")[-1]
 
         claim_messages = self.construct_index_image_claim_messages(index_image, tag, [signing_key])
         signature_messages = self.get_signatures_from_radas(claim_messages)

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -605,7 +605,7 @@ class OperatorSignatureHandler(SignatureHandler):
             ),
         )
 
-    def sign_task_index_image(self, build_details, signing_key, index_image, tag=None):
+    def sign_task_index_image(self, signing_key, index_image, tag):
         """
         Perform an alternatve signing workflow used by IIB methods in pub.
 
@@ -613,19 +613,13 @@ class OperatorSignatureHandler(SignatureHandler):
         'PushIIBBuildFromScratch'.
 
         Args:
-            build_details (dict):
-                Build details produced by IIB.
             signing_key (str):
                 Signing key to be used.
             index_image (str):
-                Index image to be signed.
-            tag (str|None):
-                Tag of the result index image. If not specified, it's derived from the provided
-                index image.
+                Index image pointing to the new manifest list.
+            tag (str):
+                Tag of the result index image.
         """
-        if tag is None:
-            tag = index_image.split(":")[-1]
-
         claim_messages = self.construct_index_image_claim_messages(index_image, tag, [signing_key])
         signature_messages = self.get_signatures_from_radas(claim_messages)
         self.validate_radas_messages(claim_messages, signature_messages)

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -605,7 +605,7 @@ class OperatorSignatureHandler(SignatureHandler):
             ),
         )
 
-    def sign_task_index_image(self, signing_key, index_image, tag):
+    def sign_task_index_image(self, signing_keys, index_image, tag):
         """
         Perform an alternatve signing workflow used by IIB methods in pub.
 
@@ -613,14 +613,14 @@ class OperatorSignatureHandler(SignatureHandler):
         'PushIIBBuildFromScratch'.
 
         Args:
-            signing_key (str):
+            signing_keys ([str]):
                 Signing key to be used.
             index_image (str):
                 Index image pointing to the new manifest list.
             tag (str):
                 Tag of the result index image.
         """
-        claim_messages = self.construct_index_image_claim_messages(index_image, tag, [signing_key])
+        claim_messages = self.construct_index_image_claim_messages(index_image, tag, signing_keys)
         signature_messages = self.get_signatures_from_radas(claim_messages)
         self.validate_radas_messages(claim_messages, signature_messages)
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,10 @@ setup(
             "pubtools-quay-untag = pubtools._quay.untag_images:untag_images_main",
         ],
         "target": [
-            "push-docker = pubtools._quay.push_docker:mod_entry_point"
+            "push-docker = pubtools._quay.push_docker:mod_entry_point",
+            "iib-add-bundles = pubtools._quay.iib_operations:iib_add_entrypoint",
+            "iib-remove-operators = pubtools._quay.iib_operations:iib_remove_entrypoint",
+            "iib-build-from-scratch = pubtools._quay.iib_operations:iib_from_scratch_entrypoint",
         ]
     },
     include_package_data=True,

--- a/tests/test_container_pusher.py
+++ b/tests/test_container_pusher.py
@@ -39,7 +39,9 @@ def test_tag_images(
         [container_multiarch_push_item], target_settings
     )
 
-    pusher.run_tag_images("source-ref:1", ["dest-ref:1", "dest-ref:2"], True)
+    pusher.run_tag_images(
+        "source-ref:1", ["dest-ref:1", "dest-ref:2"], True, pusher.target_settings
+    )
     mock_tag_images.assert_called_once_with(
         "source-ref:1",
         ["dest-ref:1", "dest-ref:2"],

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -79,7 +79,7 @@ def test_task_iib_add_bundles(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "quay.io/some-namespace/operators----index-image:8"
+        build_details, "some-key", "some-registry.com/new-index-image:8"
     )
 
 
@@ -130,7 +130,7 @@ def test_task_iib_remove_operators(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "quay.io/some-namespace/operators----index-image:8"
+        build_details, "some-key", "some-registry.com/new-index-image:8"
     )
 
 
@@ -180,7 +180,7 @@ def test_task_iib_build_from_scratch(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "quay.io/some-namespace/operators----index-image:12"
+        build_details, "some-key", "some-registry.com/new-index-image:8", tag="12"
     )
 
 

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -79,7 +79,7 @@ def test_task_iib_add_bundles(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "some-registry.com/new-index-image:8"
+        "some-key", "quay.io/some-namespace/iib:8", "8"
     )
 
 
@@ -130,7 +130,7 @@ def test_task_iib_remove_operators(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "some-registry.com/new-index-image:8"
+        "some-key", "quay.io/some-namespace/iib:8", "8"
     )
 
 
@@ -180,7 +180,7 @@ def test_task_iib_build_from_scratch(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        build_details, "some-key", "some-registry.com/new-index-image:8", tag="12"
+        "some-key", "quay.io/some-namespace/iib:8", "12"
     )
 
 

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -1,0 +1,258 @@
+import mock
+import pytest
+
+from pubtools._quay import exceptions
+from pubtools._quay import iib_operations
+
+
+def test_verify_target_settings_success(target_settings):
+    iib_operations.verify_target_settings(target_settings)
+
+
+def test_verify_target_settings_missing_setting(target_settings):
+    target_settings.pop("quay_user")
+    with pytest.raises(exceptions.InvalidTargetSettings, match="'quay_user' must be present.*"):
+        iib_operations.verify_target_settings(target_settings)
+
+
+def test_verify_target_settings_missing_docker_setting(target_settings):
+    target_settings["docker_settings"].pop("umb_urls")
+    with pytest.raises(
+        exceptions.InvalidTargetSettings,
+        match="'umb_urls' must be present in the docker settings.*",
+    ):
+        iib_operations.verify_target_settings(target_settings)
+
+
+def test_verify_target_settings_overwrite_index_mismatch(target_settings):
+    target_settings.pop("iib_overwrite_from_index_token")
+    with pytest.raises(exceptions.InvalidTargetSettings, match="Either both or neither.*"):
+        iib_operations.verify_target_settings(target_settings)
+
+
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+def test_task_iib_add_bundles(
+    mock_verify_target_settings,
+    mock_iib_add_bundles,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    target_settings,
+):
+    class IIBRes:
+        def __init__(self, index_image):
+            self.index_image = index_image
+
+    build_details = IIBRes("some-registry.com/new-index-image:8")
+    mock_iib_add_bundles.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_add_bundles(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        ["bundle3", "bundle4"],
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_add_bundles.assert_called_once_with(
+        bundles=["bundle1", "bundle2"],
+        archs=["arch1", "arch2"],
+        index_image="some-registry.com/index-image:5",
+        deprecation_list=["bundle3", "bundle4"],
+        target_settings=target_settings,
+    )
+    mock_run_tag_images.assert_called_once_with(
+        "some-registry.com/new-index-image:8",
+        ["quay.io/some-namespace/operators----index-image:8"],
+        True,
+        target_settings,
+    )
+    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_sign_task_index_image.assert_called_once_with(
+        build_details, "some-key", "quay.io/some-namespace/operators----index-image:8"
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_remove_operators")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+def test_task_iib_remove_operators(
+    mock_verify_target_settings,
+    mock_iib_remove_operators,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    target_settings,
+):
+    class IIBRes:
+        def __init__(self, index_image):
+            self.index_image = index_image
+
+    build_details = IIBRes("some-registry.com/new-index-image:8")
+    mock_iib_remove_operators.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_remove_operators(
+        ["operator1", "operator2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_remove_operators.assert_called_once_with(
+        operators=["operator1", "operator2"],
+        archs=["arch1", "arch2"],
+        index_image="some-registry.com/index-image:5",
+        target_settings=target_settings,
+    )
+    mock_run_tag_images.assert_called_once_with(
+        "some-registry.com/new-index-image:8",
+        ["quay.io/some-namespace/operators----index-image:8"],
+        True,
+        target_settings,
+    )
+    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_sign_task_index_image.assert_called_once_with(
+        build_details, "some-key", "quay.io/some-namespace/operators----index-image:8"
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+def test_task_iib_build_from_scratch(
+    mock_verify_target_settings,
+    mock_iib_add_bundles,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    target_settings,
+):
+    class IIBRes:
+        def __init__(self, index_image):
+            self.index_image = index_image
+
+    build_details = IIBRes("some-registry.com/new-index-image:8")
+    mock_iib_add_bundles.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_build_from_scratch(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "12",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_add_bundles.assert_called_once_with(
+        bundles=["bundle1", "bundle2"],
+        archs=["arch1", "arch2"],
+        target_settings=target_settings,
+    )
+    mock_run_tag_images.assert_called_once_with(
+        "some-registry.com/new-index-image:8",
+        ["quay.io/some-namespace/operators----index-image:12"],
+        True,
+        target_settings,
+    )
+    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_sign_task_index_image.assert_called_once_with(
+        build_details, "some-key", "quay.io/some-namespace/operators----index-image:12"
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.task_iib_add_bundles")
+def test_iib_add_entrypoint(mock_add_bundles, target_settings):
+    mock_hub = mock.MagicMock()
+    iib_operations.iib_add_entrypoint(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        ["bundle3", "bundle4"],
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_add_bundles.assert_called_once_with(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        ["bundle3", "bundle4"],
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.task_iib_remove_operators")
+def test_iib_remove_entrypoint(mock_remove_operators, target_settings):
+    mock_hub = mock.MagicMock()
+    iib_operations.iib_remove_entrypoint(
+        ["operator1", "operator2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_remove_operators.assert_called_once_with(
+        ["operator1", "operator2"],
+        ["arch1", "arch2"],
+        "some-registry.com/index-image:5",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.task_iib_build_from_scratch")
+def test_iib_from_scratch_entrypoint(mock_build_from_scratch, target_settings):
+    mock_hub = mock.MagicMock()
+    iib_operations.iib_from_scratch_entrypoint(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "12",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )
+
+    mock_build_from_scratch.assert_called_once_with(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "12",
+        "some-key",
+        mock_hub,
+        "1",
+        target_settings,
+    )

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -42,10 +42,14 @@ def test_task_iib_add_bundles(
     target_settings,
 ):
     class IIBRes:
-        def __init__(self, index_image):
+        def __init__(self, index_image, index_image_resolved):
             self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
 
-    build_details = IIBRes("some-registry.com/new-index-image:8")
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
     mock_iib_add_bundles.return_value = build_details
 
     mock_sign_task_index_image = mock.MagicMock()
@@ -55,7 +59,7 @@ def test_task_iib_add_bundles(
     iib_operations.task_iib_add_bundles(
         ["bundle1", "bundle2"],
         ["arch1", "arch2"],
-        "some-registry.com/index-image:5",
+        "some-registry.com/redhat-namespace/new-index-image:5",
         ["bundle3", "bundle4"],
         ["some-key"],
         mock_hub,
@@ -67,19 +71,19 @@ def test_task_iib_add_bundles(
     mock_iib_add_bundles.assert_called_once_with(
         bundles=["bundle1", "bundle2"],
         archs=["arch1", "arch2"],
-        index_image="some-registry.com/index-image:5",
+        index_image="some-registry.com/redhat-namespace/new-index-image:5",
         deprecation_list=["bundle3", "bundle4"],
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
-        "some-registry.com/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image:8",
         ["quay.io/some-namespace/operators----index-image:8"],
         True,
         target_settings,
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/some-namespace/iib:8", "8"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
     )
 
 
@@ -95,10 +99,14 @@ def test_task_iib_remove_operators(
     target_settings,
 ):
     class IIBRes:
-        def __init__(self, index_image):
+        def __init__(self, index_image, index_image_resolved):
             self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
 
-    build_details = IIBRes("some-registry.com/new-index-image:8")
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
     mock_iib_remove_operators.return_value = build_details
 
     mock_sign_task_index_image = mock.MagicMock()
@@ -108,7 +116,7 @@ def test_task_iib_remove_operators(
     iib_operations.task_iib_remove_operators(
         ["operator1", "operator2"],
         ["arch1", "arch2"],
-        "some-registry.com/index-image:5",
+        "some-registry.com/redhat-namespace/new-index-image:5",
         ["some-key"],
         mock_hub,
         "1",
@@ -119,18 +127,18 @@ def test_task_iib_remove_operators(
     mock_iib_remove_operators.assert_called_once_with(
         operators=["operator1", "operator2"],
         archs=["arch1", "arch2"],
-        index_image="some-registry.com/index-image:5",
+        index_image="some-registry.com/redhat-namespace/new-index-image:5",
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
-        "some-registry.com/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image:8",
         ["quay.io/some-namespace/operators----index-image:8"],
         True,
         target_settings,
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/some-namespace/iib:8", "8"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
     )
 
 
@@ -146,10 +154,14 @@ def test_task_iib_build_from_scratch(
     target_settings,
 ):
     class IIBRes:
-        def __init__(self, index_image):
+        def __init__(self, index_image, index_image_resolved):
             self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
 
-    build_details = IIBRes("some-registry.com/new-index-image:8")
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
     mock_iib_add_bundles.return_value = build_details
 
     mock_sign_task_index_image = mock.MagicMock()
@@ -173,14 +185,14 @@ def test_task_iib_build_from_scratch(
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
-        "some-registry.com/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image:8",
         ["quay.io/some-namespace/operators----index-image:12"],
         True,
         target_settings,
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/some-namespace/iib:8", "12"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "12"
     )
 
 

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -57,7 +57,7 @@ def test_task_iib_add_bundles(
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
         ["bundle3", "bundle4"],
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -79,7 +79,7 @@ def test_task_iib_add_bundles(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        "some-key", "quay.io/some-namespace/iib:8", "8"
+        ["some-key"], "quay.io/some-namespace/iib:8", "8"
     )
 
 
@@ -109,7 +109,7 @@ def test_task_iib_remove_operators(
         ["operator1", "operator2"],
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -130,7 +130,7 @@ def test_task_iib_remove_operators(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        "some-key", "quay.io/some-namespace/iib:8", "8"
+        ["some-key"], "quay.io/some-namespace/iib:8", "8"
     )
 
 
@@ -160,7 +160,7 @@ def test_task_iib_build_from_scratch(
         ["bundle1", "bundle2"],
         ["arch1", "arch2"],
         "12",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -180,7 +180,7 @@ def test_task_iib_build_from_scratch(
     )
     mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
     mock_sign_task_index_image.assert_called_once_with(
-        "some-key", "quay.io/some-namespace/iib:8", "12"
+        ["some-key"], "quay.io/some-namespace/iib:8", "12"
     )
 
 
@@ -192,7 +192,7 @@ def test_iib_add_entrypoint(mock_add_bundles, target_settings):
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
         ["bundle3", "bundle4"],
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -203,7 +203,7 @@ def test_iib_add_entrypoint(mock_add_bundles, target_settings):
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
         ["bundle3", "bundle4"],
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -217,7 +217,7 @@ def test_iib_remove_entrypoint(mock_remove_operators, target_settings):
         ["operator1", "operator2"],
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -227,7 +227,7 @@ def test_iib_remove_entrypoint(mock_remove_operators, target_settings):
         ["operator1", "operator2"],
         ["arch1", "arch2"],
         "some-registry.com/index-image:5",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -241,7 +241,7 @@ def test_iib_from_scratch_entrypoint(mock_build_from_scratch, target_settings):
         ["bundle1", "bundle2"],
         ["arch1", "arch2"],
         "12",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,
@@ -251,7 +251,7 @@ def test_iib_from_scratch_entrypoint(mock_build_from_scratch, target_settings):
         ["bundle1", "bundle2"],
         ["arch1", "arch2"],
         "12",
-        "some-key",
+        ["some-key"],
         mock_hub,
         "1",
         target_settings,

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -142,7 +142,7 @@ def test_get_deprecation_list_invalid_data(target_settings, operator_push_item_o
 
 
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
-def test_iib_add_bundles(
+def test_iib_add_bundles_str_deprecation_list(
     mock_run_entrypoint,
     target_settings,
     operator_push_item_ok,
@@ -154,6 +154,52 @@ def test_iib_add_bundles(
         ["arch1", "arch2"],
         "registry.com/rh-osbs/iib-pub-pending:v4.5",
         "bundle3,bundle4",
+        pusher.target_settings,
+    )
+
+    assert result == "some-data"
+    mock_run_entrypoint.assert_called_once_with(
+        ("pubtools-iib", "console_scripts", "pubtools-iib-add-bundles"),
+        "pubtools-iib-add-bundles",
+        [
+            "--skip-pulp",
+            "--iib-server",
+            "iib-server.com",
+            "--iib-krb-principal",
+            "some-principal@REDHAT.COM",
+            "--overwrite-from-index",
+            "--iib-krb-ktfile",
+            "/etc/pub/some.keytab",
+            "--index-image",
+            "registry.com/rh-osbs/iib-pub-pending:v4.5",
+            "--bundle",
+            "bundle1",
+            "--bundle",
+            "bundle2",
+            "--arch",
+            "arch1",
+            "--arch",
+            "arch2",
+            "--deprecation-list",
+            "bundle3,bundle4",
+        ],
+        {"OVERWRITE_FROM_INDEX_TOKEN": "some-token"},
+    )
+
+
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_iib_add_bundles_list_deprecation_list(
+    mock_run_entrypoint,
+    target_settings,
+    operator_push_item_ok,
+):
+    mock_run_entrypoint.return_value = "some-data"
+    pusher = operator_pusher.OperatorPusher([operator_push_item_ok], target_settings)
+    result = pusher.iib_add_bundles(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "registry.com/rh-osbs/iib-pub-pending:v4.5",
+        ["bundle3", "bundle4"],
         pusher.target_settings,
     )
 

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -150,7 +150,11 @@ def test_iib_add_bundles(
     mock_run_entrypoint.return_value = "some-data"
     pusher = operator_pusher.OperatorPusher([operator_push_item_ok], target_settings)
     result = pusher.iib_add_bundles(
-        ["bundle1", "bundle2"], ["arch1", "arch2"], "v4.5", ["bundle3", "bundle4"]
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "registry.com/rh-osbs/iib-pub-pending:v4.5",
+        "bundle3,bundle4",
+        pusher.target_settings,
     )
 
     assert result == "some-data"
@@ -183,7 +187,50 @@ def test_iib_add_bundles(
     )
 
 
-@mock.patch("pubtools._quay.operator_pusher.tag_images")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_iib_remove_operators(
+    mock_run_entrypoint,
+    target_settings,
+    operator_push_item_ok,
+):
+    mock_run_entrypoint.return_value = "some-data"
+    pusher = operator_pusher.OperatorPusher([operator_push_item_ok], target_settings)
+    result = pusher.iib_remove_operators(
+        ["operator1", "operator2"],
+        ["arch1", "arch2"],
+        "registry.com/rh-osbs/iib-pub-pending:v4.5",
+        pusher.target_settings,
+    )
+
+    assert result == "some-data"
+    mock_run_entrypoint.assert_called_once_with(
+        ("pubtools-iib", "console_scripts", "pubtools-iib-remove-operators"),
+        "pubtools-iib-remove-operators",
+        [
+            "--skip-pulp",
+            "--iib-server",
+            "iib-server.com",
+            "--iib-krb-principal",
+            "some-principal@REDHAT.COM",
+            "--overwrite-from-index",
+            "--iib-krb-ktfile",
+            "/etc/pub/some.keytab",
+            "--index-image",
+            "registry.com/rh-osbs/iib-pub-pending:v4.5",
+            "--operator",
+            "operator1",
+            "--operator",
+            "operator2",
+            "--arch",
+            "arch1",
+            "--arch",
+            "arch2",
+        ],
+        {"OVERWRITE_FROM_INDEX_TOKEN": "some-token"},
+    )
+
+
+@mock.patch("pubtools._quay.operator_pusher.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.operator_pusher.OperatorPusher.iib_add_bundles")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
 @mock.patch("pubtools._quay.operator_pusher.OperatorPusher.get_deprecation_list")
@@ -191,7 +238,7 @@ def test_push_operators(
     mock_get_deprecation_list,
     mock_run_entrypoint,
     mock_add_bundles,
-    mock_tag_images,
+    mock_run_tag_images,
     target_settings,
     operator_push_item_ok,
     operator_push_item_different_version,
@@ -230,66 +277,45 @@ def test_push_operators(
     }
     assert mock_add_bundles.call_count == 3
     assert mock_add_bundles.call_args_list[0] == mock.call(
-        ["some-registry1.com/repo:1.0"], ["some-arch"], "v4.5", ["bundle1", "bundle2"]
+        bundles=["some-registry1.com/repo:1.0"],
+        archs=["some-arch"],
+        index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
+        deprecation_list=["bundle1", "bundle2"],
+        target_settings=target_settings,
     )
     assert mock_add_bundles.call_args_list[1] == mock.call(
-        ["some-registry1.com/repo:1.0"], ["some-arch"], "v4.6", ["bundle3"]
+        bundles=["some-registry1.com/repo:1.0"],
+        archs=["some-arch"],
+        index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
+        deprecation_list=["bundle3"],
+        target_settings=target_settings,
     )
     assert mock_add_bundles.call_args_list[2] == mock.call(
-        ["some-registry1.com/repo:1.0", "some-registry1.com/repo2:5.0.0"],
-        ["amd64", "some-arch"],
-        "v4.7",
-        [],
+        bundles=["some-registry1.com/repo:1.0", "some-registry1.com/repo2:5.0.0"],
+        archs=["amd64", "some-arch"],
+        index_image="registry.com/rh-osbs/iib-pub-pending:v4.7",
+        deprecation_list=[],
+        target_settings=target_settings,
     )
 
     pusher.push_index_images(results)
 
-    assert mock_tag_images.call_count == 3
-    assert mock_tag_images.call_args_list[0] == mock.call(
+    assert mock_run_tag_images.call_count == 3
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
         "some-registry.com/index-image:5",
         ["quay.io/some-namespace/operators----index-image:5"],
-        all_arch=True,
-        quay_user="quay-user",
-        quay_password="quay-pass",
-        remote_exec=True,
-        send_umb_msg=True,
-        ssh_remote_host="127.0.0.1",
-        ssh_username="ssh-user",
-        ssh_password="ssh-password",
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        True,
+        target_settings,
     )
-    assert mock_tag_images.call_args_list[1] == mock.call(
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
         "some-registry.com/index-image:6",
         ["quay.io/some-namespace/operators----index-image:6"],
-        all_arch=True,
-        quay_user="quay-user",
-        quay_password="quay-pass",
-        remote_exec=True,
-        send_umb_msg=True,
-        ssh_remote_host="127.0.0.1",
-        ssh_username="ssh-user",
-        ssh_password="ssh-password",
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        True,
+        target_settings,
     )
-    assert mock_tag_images.call_args_list[2] == mock.call(
+    assert mock_run_tag_images.call_args_list[2] == mock.call(
         "some-registry.com/index-image:7",
         ["quay.io/some-namespace/operators----index-image:7"],
-        all_arch=True,
-        quay_user="quay-user",
-        quay_password="quay-pass",
-        remote_exec=True,
-        send_umb_msg=True,
-        ssh_remote_host="127.0.0.1",
-        ssh_username="ssh-user",
-        ssh_password="ssh-password",
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        True,
+        target_settings,
     )

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -676,7 +676,7 @@ def test_sign_task_index_image(
     build_details = IIBRes("registry1/namespace/image:1")
 
     sig_handler = signature_handler.OperatorSignatureHandler(hub, "1", target_settings)
-    sig_handler.sign_task_index_image("some-key", "registry1/namespace/image:1", "3")
+    sig_handler.sign_task_index_image(["some-key"], "registry1/namespace/image:1", "3")
     mock_construct_index_claim_msgs.assert_called_once_with(
         "registry1/namespace/image:1", "3", ["some-key"]
     )

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -683,3 +683,39 @@ def test_sign_task_index_image(
     mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2"])
     mock_validate_radas_msgs.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"])
     mock_upload_signatures_to_pyxis.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"], 100)
+
+
+@mock.patch("pubtools._quay.signature_handler.SignatureHandler.upload_signatures_to_pyxis")
+@mock.patch("pubtools._quay.signature_handler.SignatureHandler.validate_radas_messages")
+@mock.patch("pubtools._quay.signature_handler.SignatureHandler.get_signatures_from_radas")
+@mock.patch(
+    "pubtools._quay.signature_handler.OperatorSignatureHandler.construct_index_image_claim_messages"
+)
+@mock.patch("pubtools._quay.signature_handler.QuayClient")
+@mock.patch("pubtools._quay.signature_handler.QuayApiClient")
+def test_sign_task_index_image_custom_tag(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_construct_index_claim_msgs,
+    mock_get_radas_signatures,
+    mock_validate_radas_msgs,
+    mock_upload_signatures_to_pyxis,
+    target_settings,
+):
+    class IIBRes:
+        def __init__(self, index_image_resolved):
+            self.index_image_resolved = index_image_resolved
+
+    hub = mock.MagicMock()
+    mock_construct_index_claim_msgs.return_value = ["msg1", "msg2"]
+    mock_get_radas_signatures.return_value = ["sig1", "sig2"]
+    build_details = IIBRes("registry1/namespace/image:1")
+
+    sig_handler = signature_handler.OperatorSignatureHandler(hub, "1", target_settings)
+    sig_handler.sign_task_index_image(build_details, "some-key", "registry1/namespace/image:1", "3")
+    mock_construct_index_claim_msgs.assert_called_once_with(
+        "registry1/namespace/image:1", "3", ["some-key"]
+    )
+    mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2"])
+    mock_validate_radas_msgs.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"])
+    mock_upload_signatures_to_pyxis.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"], 100)

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -676,43 +676,7 @@ def test_sign_task_index_image(
     build_details = IIBRes("registry1/namespace/image:1")
 
     sig_handler = signature_handler.OperatorSignatureHandler(hub, "1", target_settings)
-    sig_handler.sign_task_index_image(build_details, "some-key", "registry1/namespace/image:1")
-    mock_construct_index_claim_msgs.assert_called_once_with(
-        "registry1/namespace/image:1", "1", ["some-key"]
-    )
-    mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2"])
-    mock_validate_radas_msgs.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"])
-    mock_upload_signatures_to_pyxis.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"], 100)
-
-
-@mock.patch("pubtools._quay.signature_handler.SignatureHandler.upload_signatures_to_pyxis")
-@mock.patch("pubtools._quay.signature_handler.SignatureHandler.validate_radas_messages")
-@mock.patch("pubtools._quay.signature_handler.SignatureHandler.get_signatures_from_radas")
-@mock.patch(
-    "pubtools._quay.signature_handler.OperatorSignatureHandler.construct_index_image_claim_messages"
-)
-@mock.patch("pubtools._quay.signature_handler.QuayClient")
-@mock.patch("pubtools._quay.signature_handler.QuayApiClient")
-def test_sign_task_index_image_custom_tag(
-    mock_quay_api_client,
-    mock_quay_client,
-    mock_construct_index_claim_msgs,
-    mock_get_radas_signatures,
-    mock_validate_radas_msgs,
-    mock_upload_signatures_to_pyxis,
-    target_settings,
-):
-    class IIBRes:
-        def __init__(self, index_image_resolved):
-            self.index_image_resolved = index_image_resolved
-
-    hub = mock.MagicMock()
-    mock_construct_index_claim_msgs.return_value = ["msg1", "msg2"]
-    mock_get_radas_signatures.return_value = ["sig1", "sig2"]
-    build_details = IIBRes("registry1/namespace/image:1")
-
-    sig_handler = signature_handler.OperatorSignatureHandler(hub, "1", target_settings)
-    sig_handler.sign_task_index_image(build_details, "some-key", "registry1/namespace/image:1", "3")
+    sig_handler.sign_task_index_image("some-key", "registry1/namespace/image:1", "3")
     mock_construct_index_claim_msgs.assert_called_once_with(
         "registry1/namespace/image:1", "3", ["some-key"]
     )


### PR DESCRIPTION
The new entrypoints are meant to be used by the pub methods
"PushAddIIBBundles", "PushRemoveIIBOperators", and
"PushIIBBuildFromScratch" and are invoked similiarly as push-docker.
To avoid code duplication, several methods were turned to class
methods so they could be invoked independently from the object's
context. Namely, these are: "iib_add_bundles", "iib_remove_operators",
and "run_tag_images". Image signing workflow unique to these pub
tasks was implemented in "sign_task_index_image".

One original design decision has changed by this task: it was decided
that pubtools-iib will not invoke pubtools-quay for pushing the new
index image to quay. Instead, the logic for calling pubtools-iib,
and subsequently pushing the image to its destination will be handled
in pubtools-quay. This was decided to avoid increasing the complexity
of pubtools-iib, and to simplify the implementation on pub's side.

Side effect is that the full operator workflow cannot be invoked as
a CLI script. The reason for this decision is that the original
design hasn't accounted for index image signing, which wouldn't be
performed by a CLI script anyway. The current technical solution
allows for an extension of CLI capabilities, but the argument input
would be complex and the script would still need to contact pub-hub
for the signing operation.