### PR TITLE
Fix intermediate index image

### DIFF
--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -570,7 +570,7 @@ class OperatorSignatureHandler(SignatureHandler):
             iib_results ({str:dict}):
                 IIB results for each version the push was performed for.
         """
-        image_schema = "{host}/{namespace}/{repo}:{tag}"
+        image_schema = "{host}/{namespace}/{repo}@{digest}"
         if not self.target_settings["docker_settings"].get(
             "docker_container_signing_enabled", False
         ):
@@ -582,12 +582,13 @@ class OperatorSignatureHandler(SignatureHandler):
             iib_result = iib_details["iib_result"]
             signing_keys = iib_details["signing_keys"]
             # Using intermediate index image to ensure that it doesn't get overwritten
-            _, tag = iib_result.index_image.split(":", 1)
+            iib_namespace = iib_result.index_image_resolved.split("/")[1]
+            image_digest = iib_result.index_image_resolved.split("@")[1]
             intermediate_index_image = image_schema.format(
                 host=self.target_settings.get("quay_host", "quay.io").rstrip("/"),
-                namespace=self.target_settings["quay_namespace"],
+                namespace=iib_namespace,
                 repo="iib",
-                tag=tag,
+                digest=image_digest,
             )
             # Version acts as a tag of the index image
             claim_messages += self.construct_index_image_claim_messages(

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -591,25 +591,31 @@ def test_sign_operator_images(
     target_settings,
 ):
     class IIBRes:
-        def __init__(self, index_image):
-            self.index_image = index_image
+        def __init__(self, index_image_resolved):
+            self.index_image_resolved = index_image_resolved
 
     hub = mock.MagicMock()
     mock_construct_index_claim_msgs.side_effect = [["msg1", "msg2"], ["msg3", "msg4"]]
     mock_get_radas_signatures.return_value = ["sig1", "sig2", "sig3", "sig4"]
     iib_results = {
-        "v4.5": {"iib_result": IIBRes("registry1/namespace/image:1"), "signing_keys": ["key1"]},
-        "v4.6": {"iib_result": IIBRes("registry1/namespace/image:2"), "signing_keys": ["key2"]},
+        "v4.5": {
+            "iib_result": IIBRes("registry1/iib-namespace/image@sha256:a1a1a1"),
+            "signing_keys": ["key1"],
+        },
+        "v4.6": {
+            "iib_result": IIBRes("registry1/iib-namespace/image@sha256:b2b2b2"),
+            "signing_keys": ["key2"],
+        },
     }
 
     sig_handler = signature_handler.OperatorSignatureHandler(hub, "1", target_settings)
     sig_handler.sign_operator_images(iib_results)
     assert mock_construct_index_claim_msgs.call_count == 2
     mock_construct_index_claim_msgs.call_args_list[0] == mock.call(
-        "quay.io/some-namespace/iib:1", "v4.5", ["key1"]
+        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", ["key1"]
     )
     mock_construct_index_claim_msgs.call_args_list[0] == mock.call(
-        "quay.io/some-namespace/iib:2", "v4.6", ["key2"]
+        "quay.io/iib-namespace/iib@sha256:b2b2b2", "v4.6", ["key2"]
     )
     mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])
     mock_validate_radas_msgs.assert_called_once_with(


### PR DESCRIPTION
Fix intermediate index image to use the namespace of the built index
image as well as the digest of index_image_resolved. Previous
implementation used incorrect namespace and tag.

Refers to CLOUDDST-6124