### PR TITLE
Support external repos for push items

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -231,7 +231,6 @@ class PushDocker:
         """
         repos = []
         for item in push_items:
-            LOG.info("ITEM %s", item)
             if item.external_repos:
                 repos += item.external_repos.keys()
             else:

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -150,7 +150,7 @@ class PushDocker:
         for push_item in push_items:
             if push_item.external_repos:
                 #  if external repos is defined, push items was populated by ET
-                #  item.repos have to be remove from tags mapping
+                #  item.repos have to be removed from tags mapping
                 for repo in list(push_item.repos):
                     push_item.metadata["tags"].pop(repo)
 

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -146,7 +146,12 @@ class PushDocker:
 
     @log_step("Translate docker push items")
     def filter_unrelated_repos(self, push_items):
-        """Remove item repos from tag mapping if external_repos is set for push item."""
+        """Remove item repos from tag mapping if external_repos is set for push item.
+
+        Args:
+            push_items ([ContainerPushItem]):
+                Container push items containing the repositories.
+        """
         for push_item in push_items:
             if push_item.external_repos:
                 #  if external repos is defined, push items was populated by ET

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,7 @@ class MockContainerPushItem(object):
         """Init ContainerPushItem with all args passed here."""
         self.errors = {}
         self.repos = {}
+        self.external_repos = {}
         self.state = None
         for key, val in kwargs.items():
             setattr(self, key, val)
@@ -88,6 +89,37 @@ def container_push_item_ok():
             },
             "destination": {"tags": {"repo": ["tag1"]}},
             "tags": {"test-repo": ["latest-test-tag", "1.0"]},
+            "v_r": "1.0",
+        },
+    )
+
+
+@pytest.fixture
+def container_push_item_external_repos():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="push_item_origin",
+        repos={"test_repo": []},
+        external_repos={"external/repo": []},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "destination": {"tags": {"repo": ["tag1"]}},
+            "tags": {
+                "test_repo": ["latest-test-tag", "1.0"],
+                "external/repo": ["latest-test-tag", "1.0"],
+            },
             "v_r": "1.0",
         },
     )

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -30,7 +30,10 @@ def test_init_verify_target_settings_ok(
         "some-target",
         target_settings,
     )
-    assert push_docker_instance.push_items == [container_multiarch_push_item, operator_push_item_ok]
+    assert push_docker_instance.push_items == [
+        container_multiarch_push_item,
+        operator_push_item_ok,
+    ]
     assert push_docker_instance.hub == hub
     assert push_docker_instance.task_id == "1"
     assert push_docker_instance.target_name == "some-target"
@@ -120,7 +123,11 @@ def test_get_container_push_items_ok(
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [container_multiarch_push_item, operator_push_item_ok, container_source_push_item],
+        [
+            container_multiarch_push_item,
+            operator_push_item_ok,
+            container_source_push_item,
+        ],
         hub,
         "1",
         "some-target",
@@ -365,6 +372,7 @@ def test_check_repos_validity_success(
     target_settings,
     container_push_item_correct_repos,
     container_signing_push_item,
+    container_push_item_external_repos,
 ):
     mock_get_target_info = mock.MagicMock()
     mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage_namespace"}}
@@ -374,10 +382,11 @@ def test_check_repos_validity_success(
     hub.worker = mock_worker
 
     mock_get_repository_data = mock.MagicMock()
-    mock_get_repository_data.side_effect = ["repo_data1", "repo_data2"]
+    mock_get_repository_data.side_effect = ["repo_data1", "repo_data2", "repo_data3"]
     mock_quay_api_client.return_value.get_repository_data = mock_get_repository_data
 
     mock_get_repo_metadata.side_effect = [
+        {"release_categories": "value2"},
         {"release_categories": "value1"},
         {"release_categories": "value2"},
     ]
@@ -390,14 +399,18 @@ def test_check_repos_validity_success(
         target_settings,
     )
     push_docker_instance.check_repos_validity(
-        [container_push_item_correct_repos, container_signing_push_item]
+        [
+            container_push_item_external_repos,
+            container_push_item_correct_repos,
+            container_signing_push_item,
+        ]
     )
 
     mock_get_target_info.assert_called_once_with("target_stage_quay")
-    assert mock_get_repo_metadata.call_count == 2
+    assert mock_get_repo_metadata.call_count == 3
     mock_get_repo_metadata.call_args_list[0] == mock.call("namespace/repo1")
     mock_get_repo_metadata.call_args_list[1] == mock.call("namespace/repo2")
-    assert mock_get_repository_data.call_count == 2
+    assert mock_get_repository_data.call_count == 3
     mock_get_repository_data.call_args_list[0] == mock.call("some-namespace/namespace----repo1")
     mock_get_repository_data.call_args_list[1] == mock.call("some-namespace/namespace----repo2")
 
@@ -800,6 +813,7 @@ def test_push_docker_full_success(
     mock_rollback,
     target_settings,
     container_multiarch_push_item,
+    container_push_item_external_repos,
     operator_push_item_ok,
 ):
     hub = mock.MagicMock()
@@ -814,9 +828,15 @@ def test_push_docker_full_success(
     mock_sign_operator_images = mock.MagicMock()
     mock_operator_signature_handler.return_value.sign_operator_images = mock_sign_operator_images
 
-    mock_get_docker_push_items.return_value = [container_multiarch_push_item]
+    mock_get_docker_push_items.return_value = [
+        container_multiarch_push_item,
+        container_push_item_external_repos,
+    ]
     mock_get_operator_push_items.return_value = [operator_push_item_ok]
-    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
+    mock_generate_backup_mapping.return_value = (
+        {"some-key": "some-val"},
+        ["item1", "item2"],
+    )
     mock_build_index_images.return_value = {"v4.5": {"some": "data"}}
 
     push_docker_instance = push_docker.PushDocker(
@@ -830,21 +850,28 @@ def test_push_docker_full_success(
 
     mock_get_docker_push_items.assert_called_once_with()
     mock_get_docker_push_items.assert_called_once_with()
-    mock_check_repos_validity.assert_called_once_with([container_multiarch_push_item])
-    mock_generate_backup_mapping.assert_called_once_with([container_multiarch_push_item])
+    mock_check_repos_validity.assert_called_once_with(
+        [container_multiarch_push_item, container_push_item_external_repos]
+    )
+    mock_generate_backup_mapping.assert_called_once_with(
+        [container_multiarch_push_item, container_push_item_external_repos]
+    )
     mock_container_image_pusher.assert_called_once_with(
-        [container_multiarch_push_item], target_settings
+        [container_multiarch_push_item, container_push_item_external_repos],
+        target_settings,
     )
     mock_push_container_images.assert_called_once_with()
     mock_container_signature_handler.assert_called_once_with(hub, "1", target_settings)
-    mock_sign_container_images.assert_called_once_with([container_multiarch_push_item])
+    mock_sign_container_images.assert_called_once_with(
+        [container_multiarch_push_item, container_push_item_external_repos]
+    )
     mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with({"v4.5": {"some": "data"}})
     mock_operator_signature_handler.assert_called_once_with(hub, "1", target_settings)
     mock_sign_operator_images.assert_called_once_with({"v4.5": {"some": "data"}})
     mock_rollback.assert_not_called()
-    assert repos == ["test_repo"]
+    assert repos == ["external/repo", "test_repo"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -887,7 +914,10 @@ def test_push_docker_no_operator_push_items(
 
     mock_get_docker_push_items.return_value = [container_multiarch_push_item]
     mock_get_operator_push_items.return_value = []
-    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
+    mock_generate_backup_mapping.return_value = (
+        {"some-key": "some-val"},
+        ["item1", "item2"],
+    )
 
     push_docker_instance = push_docker.PushDocker(
         [container_multiarch_push_item],
@@ -959,7 +989,10 @@ def test_push_docker_failure_rollback(
 
     mock_get_docker_push_items.return_value = [container_multiarch_push_item]
     mock_get_operator_push_items.return_value = [operator_push_item_ok]
-    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
+    mock_generate_backup_mapping.return_value = (
+        {"some-key": "some-val"},
+        ["item1", "item2"],
+    )
 
     push_docker_instance = push_docker.PushDocker(
         [container_multiarch_push_item, operator_push_item_ok],
@@ -991,7 +1024,10 @@ def test_push_docker_failure_rollback(
 
 @mock.patch("pubtools._quay.push_docker.PushDocker")
 def test_mod_entrypoint(
-    mock_push_docker, container_multiarch_push_item, operator_push_item_ok, target_settings
+    mock_push_docker,
+    container_multiarch_push_item,
+    operator_push_item_ok,
+    target_settings,
 ):
     hub = mock.MagicMock()
     mock_run = mock.MagicMock()

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -354,7 +354,7 @@ def test_check_repos_validity_success(
             container_push_item_external_repos,
             container_push_item_correct_repos,
             container_signing_push_item,
-        ]
+        ],
         hub,
         target_settings,
         mock_quay_api_client,
@@ -818,7 +818,10 @@ def test_push_docker_full_success(
     mock_get_docker_push_items.assert_called_once_with()
     mock_get_docker_push_items.assert_called_once_with()
     mock_check_repos_validity.assert_called_once_with(
-        [container_multiarch_push_item, container_push_item_external_repos], hub, target_settings, mock_quay_api_client.return_value
+        [container_multiarch_push_item, container_push_item_external_repos],
+        hub,
+        target_settings,
+        mock_quay_api_client.return_value,
     )
     mock_generate_backup_mapping.assert_called_once_with(
         [container_multiarch_push_item, container_push_item_external_repos]

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -30,10 +30,7 @@ def test_init_verify_target_settings_ok(
         "some-target",
         target_settings,
     )
-    assert push_docker_instance.push_items == [
-        container_multiarch_push_item,
-        operator_push_item_ok,
-    ]
+    assert push_docker_instance.push_items == [container_multiarch_push_item, operator_push_item_ok]
     assert push_docker_instance.hub == hub
     assert push_docker_instance.task_id == "1"
     assert push_docker_instance.target_name == "some-target"
@@ -123,11 +120,7 @@ def test_get_container_push_items_ok(
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [
-            container_multiarch_push_item,
-            operator_push_item_ok,
-            container_source_push_item,
-        ],
+        [container_multiarch_push_item, operator_push_item_ok, container_source_push_item],
         hub,
         "1",
         "some-target",
@@ -140,18 +133,11 @@ def test_get_container_push_items_ok(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_container_push_items_errors(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    container_push_item_errors,
+    mock_quay_api_client, mock_quay_client, target_settings, container_push_item_errors
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [container_push_item_errors],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [container_push_item_errors], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*contains errors.*"):
         items = push_docker_instance.get_docker_push_items()
@@ -160,18 +146,11 @@ def test_get_container_push_items_errors(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_container_push_items_no_pull_data(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    container_push_item_no_metadata,
+    mock_quay_api_client, mock_quay_client, target_settings, container_push_item_no_metadata
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [container_push_item_no_metadata],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [container_push_item_no_metadata], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*doesn't contain pull data.*"):
         items = push_docker_instance.get_docker_push_items()
@@ -224,18 +203,11 @@ def test_get_operator_push_items_ok(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_operator_push_item_errors(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    operator_push_item_errors,
+    mock_quay_api_client, mock_quay_client, target_settings, operator_push_item_errors
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [operator_push_item_errors],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [operator_push_item_errors], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*contains errors.*"):
         items = push_docker_instance.get_operator_push_items()
@@ -244,18 +216,11 @@ def test_get_operator_push_item_errors(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_operator_push_item_no_op_type(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    operator_push_item_no_op_type,
+    mock_quay_api_client, mock_quay_client, target_settings, operator_push_item_no_op_type
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [operator_push_item_no_op_type],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [operator_push_item_no_op_type], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*doesn't contain 'op_type'.*"):
         items = push_docker_instance.get_operator_push_items()
@@ -285,18 +250,11 @@ def test_get_operator_push_item_op_appregistry(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_operator_push_item_unknown_op_type(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    operator_push_item_unknown_op_type,
+    mock_quay_api_client, mock_quay_client, target_settings, operator_push_item_unknown_op_type
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [operator_push_item_unknown_op_type],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [operator_push_item_unknown_op_type], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*has unknown op_type.*"):
         items = push_docker_instance.get_operator_push_items()
@@ -305,18 +263,11 @@ def test_get_operator_push_item_unknown_op_type(
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_operator_push_item_no_ocp_versions(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    operator_push_item_no_ocp,
+    mock_quay_api_client, mock_quay_client, target_settings, operator_push_item_no_ocp
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [operator_push_item_no_ocp],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [operator_push_item_no_ocp], hub, "1", "some-target", target_settings
     )
     with pytest.raises(exceptions.BadPushItem, match=".*specify 'com.redhat.openshift.versions'.*"):
         items = push_docker_instance.get_operator_push_items()
@@ -410,6 +361,7 @@ def test_check_repos_validity_success(
     assert mock_get_repo_metadata.call_count == 3
     mock_get_repo_metadata.call_args_list[0] == mock.call("namespace/repo1")
     mock_get_repo_metadata.call_args_list[1] == mock.call("namespace/repo2")
+    mock_get_repo_metadata.call_args_list[2] == mock.call("namespace/repo3")
     assert mock_get_repository_data.call_count == 3
     mock_get_repository_data.call_args_list[0] == mock.call("some-namespace/namespace----repo1")
     mock_get_repository_data.call_args_list[1] == mock.call("some-namespace/namespace----repo2")
@@ -833,10 +785,7 @@ def test_push_docker_full_success(
         container_push_item_external_repos,
     ]
     mock_get_operator_push_items.return_value = [operator_push_item_ok]
-    mock_generate_backup_mapping.return_value = (
-        {"some-key": "some-val"},
-        ["item1", "item2"],
-    )
+    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
     mock_build_index_images.return_value = {"v4.5": {"some": "data"}}
 
     push_docker_instance = push_docker.PushDocker(
@@ -857,8 +806,7 @@ def test_push_docker_full_success(
         [container_multiarch_push_item, container_push_item_external_repos]
     )
     mock_container_image_pusher.assert_called_once_with(
-        [container_multiarch_push_item, container_push_item_external_repos],
-        target_settings,
+        [container_multiarch_push_item, container_push_item_external_repos], target_settings
     )
     mock_push_container_images.assert_called_once_with()
     mock_container_signature_handler.assert_called_once_with(hub, "1", target_settings)
@@ -914,17 +862,10 @@ def test_push_docker_no_operator_push_items(
 
     mock_get_docker_push_items.return_value = [container_multiarch_push_item]
     mock_get_operator_push_items.return_value = []
-    mock_generate_backup_mapping.return_value = (
-        {"some-key": "some-val"},
-        ["item1", "item2"],
-    )
+    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
 
     push_docker_instance = push_docker.PushDocker(
-        [container_multiarch_push_item],
-        hub,
-        "1",
-        "some-target",
-        target_settings,
+        [container_multiarch_push_item], hub, "1", "some-target", target_settings
     )
     repos = push_docker_instance.run()
 
@@ -989,10 +930,7 @@ def test_push_docker_failure_rollback(
 
     mock_get_docker_push_items.return_value = [container_multiarch_push_item]
     mock_get_operator_push_items.return_value = [operator_push_item_ok]
-    mock_generate_backup_mapping.return_value = (
-        {"some-key": "some-val"},
-        ["item1", "item2"],
-    )
+    mock_generate_backup_mapping.return_value = ({"some-key": "some-val"}, ["item1", "item2"])
 
     push_docker_instance = push_docker.PushDocker(
         [container_multiarch_push_item, operator_push_item_ok],
@@ -1024,10 +962,7 @@ def test_push_docker_failure_rollback(
 
 @mock.patch("pubtools._quay.push_docker.PushDocker")
 def test_mod_entrypoint(
-    mock_push_docker,
-    container_multiarch_push_item,
-    operator_push_item_ok,
-    target_settings,
+    mock_push_docker, container_multiarch_push_item, operator_push_item_ok, target_settings
 ):
     hub = mock.MagicMock()
     mock_run = mock.MagicMock()
@@ -1049,3 +984,16 @@ def test_mod_entrypoint(
         target_settings,
     )
     mock_run.assert_called_once_with()
+
+
+@mock.patch("pubtools._quay.push_docker.PushDocker.verify_target_settings")
+def test_filter_unrelated_repos(patched_verify_target_settings, container_push_item_external_repos):
+    assert "test_repo" in container_push_item_external_repos.metadata["tags"]
+    push_docker.PushDocker(
+        [container_push_item_external_repos],
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+        mock.MagicMock(),
+    ).filter_unrelated_repos([container_push_item_external_repos])
+    assert "test_repo" not in container_push_item_external_repos.metadata["tags"]


### PR DESCRIPTION
When push items are populated by ET, they include both repos
and external_repos. In the case external repos are set, they
should be prioritized and used instead of 'repos'