### PR TITLE
Add "target_name" parameter to pub's XMLRPC call

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -33,8 +33,6 @@ class ContainerImagePusher:
         Args:
             push_items ([ContainerPushItem]):
                 List of push items.
-            target_name (str):
-                target name
             target_settings (dict):
                 Target settings.
         """

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -63,7 +63,15 @@ def verify_target_settings(target_settings):
 
 
 def task_iib_add_bundles(
-    bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
+    bundles,
+    archs,
+    index_image,
+    deprecation_list,
+    signing_keys,
+    hub,
+    task_id,
+    target_settings,
+    target_name,
 ):
     """
     Perform all the necessary actions for the 'PushAddIIBBundles' entrypoint.
@@ -85,6 +93,8 @@ def task_iib_add_bundles(
             ID of the pub task.
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
+        target_name (str):
+            Name of the target.
     """
     image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
     image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
@@ -117,7 +127,7 @@ def task_iib_add_bundles(
     )
 
     # Sign image
-    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings, target_name)
     sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, tag)
 
     # Push image to Quay
@@ -129,7 +139,7 @@ def task_iib_add_bundles(
 
 
 def task_iib_remove_operators(
-    operators, archs, index_image, signing_keys, hub, task_id, target_settings
+    operators, archs, index_image, signing_keys, hub, task_id, target_settings, target_name
 ):
     """
     Perform all the necessary actions for the 'PushRemoveIIBOperators' entrypoint.
@@ -149,6 +159,8 @@ def task_iib_remove_operators(
             ID of the pub task.
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
+        target_name (str):
+            Name of the target.
     """
     image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
     image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
@@ -181,7 +193,7 @@ def task_iib_remove_operators(
     )
 
     # Sign image
-    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings, target_name)
     sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, tag)
 
     # Push image to Quay
@@ -191,7 +203,7 @@ def task_iib_remove_operators(
 
 
 def task_iib_build_from_scratch(
-    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
+    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings, target_name
 ):
     """
     Perform all the necessary actions for the 'PushIIBBuildFromScratch' entrypoint.
@@ -211,6 +223,8 @@ def task_iib_build_from_scratch(
             ID of the pub task.
         target_settings (dict):
             Dictionary containing settings necessary for performing the operation.
+        target_name (str):
+            Name of the target.
     """
     image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
     image_schema_digest = "{host}/{namespace}/{repo}@{digest}"
@@ -242,7 +256,7 @@ def task_iib_build_from_scratch(
     )
 
     # Sign image
-    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings)
+    sig_handler = OperatorSignatureHandler(hub, task_id, target_settings, target_name)
     sig_handler.sign_task_index_image(signing_keys, intermediate_index_image, index_image_tag)
 
     # Push image to Quay
@@ -252,27 +266,43 @@ def task_iib_build_from_scratch(
 
 
 def iib_add_entrypoint(
-    bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
+    bundles,
+    archs,
+    index_image,
+    deprecation_list,
+    signing_keys,
+    hub,
+    task_id,
+    target_settings,
+    target_name,
 ):
     """Entry point for use in another python code."""
     task_iib_add_bundles(
-        bundles, archs, index_image, deprecation_list, signing_keys, hub, task_id, target_settings
+        bundles,
+        archs,
+        index_image,
+        deprecation_list,
+        signing_keys,
+        hub,
+        task_id,
+        target_settings,
+        target_name,
     )
 
 
 def iib_remove_entrypoint(
-    operators, archs, index_image, signing_keys, hub, task_id, target_settings
+    operators, archs, index_image, signing_keys, hub, task_id, target_settings, target_name
 ):
     """Entry point for use in another python code."""
     task_iib_remove_operators(
-        operators, archs, index_image, signing_keys, hub, task_id, target_settings
+        operators, archs, index_image, signing_keys, hub, task_id, target_settings, target_name
     )
 
 
 def iib_from_scratch_entrypoint(
-    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
+    bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings, target_name
 ):
     """Entry point for use in another python code."""
     task_iib_build_from_scratch(
-        bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings
+        bundles, archs, index_image_tag, signing_keys, hub, task_id, target_settings, target_name
     )

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -32,8 +32,6 @@ class OperatorPusher:
         Args:
             push_items ([ContainerPushItem]):
                 List of push items.
-            target_name (str):
-                target name
             target_settings (dict):
                 Target settings.
         """

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -38,7 +38,7 @@ class PushDocker:
             task_id (str):
                 task id
             target_name (str):
-                target name
+                Name of the target.
             target_settings (dict):
                 Target settings.
         """
@@ -413,7 +413,7 @@ class PushDocker:
         try:
             # Sign container images
             container_signature_handler = ContainerSignatureHandler(
-                self.hub, self.task_id, self.target_settings
+                self.hub, self.task_id, self.target_settings, self.target_name
             )
             container_signature_handler.sign_container_images(docker_push_items)
             # Push container images
@@ -426,7 +426,7 @@ class PushDocker:
                 iib_results = operator_pusher.build_index_images()
                 # Sign operator images
                 operator_signature_handler = OperatorSignatureHandler(
-                    self.hub, self.task_id, self.target_settings
+                    self.hub, self.task_id, self.target_settings, self.target_name
                 )
                 operator_signature_handler.sign_operator_images(iib_results)
                 # Push index images to Quay

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -27,7 +27,7 @@ class SignatureHandler:
     MAX_MANIFEST_DIGESTS_PER_SEARCH_REQUEST = 50
     DEFAULT_MAX_ITEMS_PER_UPLOAD_BATCH = 100
 
-    def __init__(self, hub, task_id, target_settings):
+    def __init__(self, hub, task_id, target_settings, target_name):
         """
         Initialize.
 
@@ -38,10 +38,13 @@ class SignatureHandler:
                 ID of the pub task
             target_settings (dict):
                 Target settings.
+            target_name (str):
+                Name of the target.
         """
         self.hub = hub
         self.task_id = task_id
         self.target_settings = target_settings
+        self.target_name = target_name
 
         # Which URL hostnames will the destination images be accessible by to customers
         self.dest_registries = target_settings["docker_settings"]["docker_reference_registry"]
@@ -289,7 +292,7 @@ class SignatureHandler:
         # callback will be utilized by ManifestClaimsHandler, which will decide when to send msgs
         message_sender_callback = (
             lambda messages: self.hub.worker.umb_send_manifest_claim_messages(  # noqa: E731
-                self.task_id, messages
+                self.target_name, self.task_id, messages
             )
         )
 
@@ -643,7 +646,7 @@ class OperatorSignatureHandler(SignatureHandler):
 class BasicSignatureHandler(SignatureHandler):
     """Class that handles signing claims which were constructed by user."""
 
-    def __init__(self, hub, target_settings):
+    def __init__(self, hub, target_settings, target_name):
         """
         Initialize.
 
@@ -654,8 +657,10 @@ class BasicSignatureHandler(SignatureHandler):
                 Instance of XMLRPC pub-hub proxy.
             target_settings (dict):
                 Target settings.
+            target_name (str):
+                Name of the target.
         """
-        SignatureHandler.__init__(self, hub, "1", target_settings)
+        SignatureHandler.__init__(self, hub, "1", target_settings, target_name)
 
     def sign_claim_messages(self, claim_messages, remove_duplicates=True, filter_existing=True):
         """

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -48,14 +48,13 @@ class TagDocker:
             task_id (str):
                 task id
             target_name (str):
-                target name
+                Name of the target.
             target_settings (dict):
                 Target settings.
         """
         self.push_items = push_items
         self.hub = hub
         self.task_id = task_id
-        # TODO: should target_name be removed? (also in PushDocker)
         self.target_name = target_name
         self.target_settings = target_settings
 
@@ -708,7 +707,7 @@ class TagDocker:
         )
         # perform tag-docker-specific checks
         self.check_input_validity()
-        signature_handler = BasicSignatureHandler(self.hub, self.target_settings)
+        signature_handler = BasicSignatureHandler(self.hub, self.target_settings, self.target_name)
 
         for item in self.push_items:
             for tag in item.metadata["add_tags"]:

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -65,6 +65,7 @@ def test_task_iib_add_bundles(
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_verify_target_settings.assert_called_once_with(target_settings)
@@ -81,7 +82,9 @@ def test_task_iib_add_bundles(
         True,
         target_settings,
     )
-    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
     mock_sign_task_index_image.assert_called_once_with(
         ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
     )
@@ -121,6 +124,7 @@ def test_task_iib_remove_operators(
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_verify_target_settings.assert_called_once_with(target_settings)
@@ -136,7 +140,9 @@ def test_task_iib_remove_operators(
         True,
         target_settings,
     )
-    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
     mock_sign_task_index_image.assert_called_once_with(
         ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
     )
@@ -176,6 +182,7 @@ def test_task_iib_build_from_scratch(
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_verify_target_settings.assert_called_once_with(target_settings)
@@ -190,7 +197,9 @@ def test_task_iib_build_from_scratch(
         True,
         target_settings,
     )
-    mock_operator_signature_handler.assert_called_once_with(mock_hub, "1", target_settings)
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
     mock_sign_task_index_image.assert_called_once_with(
         ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "12"
     )
@@ -208,6 +217,7 @@ def test_iib_add_entrypoint(mock_add_bundles, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_add_bundles.assert_called_once_with(
@@ -219,6 +229,7 @@ def test_iib_add_entrypoint(mock_add_bundles, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
 
@@ -233,6 +244,7 @@ def test_iib_remove_entrypoint(mock_remove_operators, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_remove_operators.assert_called_once_with(
@@ -243,6 +255,7 @@ def test_iib_remove_entrypoint(mock_remove_operators, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
 
@@ -257,6 +270,7 @@ def test_iib_from_scratch_entrypoint(mock_build_from_scratch, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )
 
     mock_build_from_scratch.assert_called_once_with(
@@ -267,4 +281,5 @@ def test_iib_from_scratch_entrypoint(mock_build_from_scratch, target_settings):
         mock_hub,
         "1",
         target_settings,
+        "some-target",
     )

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -830,14 +830,18 @@ def test_push_docker_full_success(
         [container_multiarch_push_item, container_push_item_external_repos], target_settings
     )
     mock_push_container_images.assert_called_once_with()
-    mock_container_signature_handler.assert_called_once_with(hub, "1", target_settings)
+    mock_container_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
     mock_sign_container_images.assert_called_once_with(
         [container_multiarch_push_item, container_push_item_external_repos]
     )
     mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with({"v4.5": {"some": "data"}})
-    mock_operator_signature_handler.assert_called_once_with(hub, "1", target_settings)
+    mock_operator_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
     mock_sign_operator_images.assert_called_once_with({"v4.5": {"some": "data"}})
     mock_rollback.assert_not_called()
     assert repos == ["external/repo", "test_repo"]
@@ -900,7 +904,9 @@ def test_push_docker_no_operator_push_items(
         [container_multiarch_push_item], target_settings
     )
     mock_push_container_images.assert_called_once_with()
-    mock_container_signature_handler.assert_called_once_with(hub, "1", target_settings)
+    mock_container_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
     mock_sign_container_images.assert_called_once_with([container_multiarch_push_item])
     mock_operator_pusher.assert_not_called()
     mock_build_index_images.assert_not_called()
@@ -975,7 +981,9 @@ def test_push_docker_failure_rollback(
         [container_multiarch_push_item], target_settings
     )
     mock_push_container_images.assert_called_once_with()
-    mock_container_signature_handler.assert_called_once_with(hub, "1", target_settings)
+    mock_container_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
     mock_sign_container_images.assert_called_once_with([container_multiarch_push_item])
     mock_operator_pusher.assert_not_called()
     mock_build_index_images.assert_not_called()

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -1997,7 +1997,7 @@ def test_run_add_noop(
         [tag_docker_push_item_add], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6"
@@ -2057,7 +2057,7 @@ def test_run_add_tag_images(
         [tag_docker_push_item_add], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6"
@@ -2123,7 +2123,7 @@ def test_run_add_merge_manifest_lists(
         [tag_docker_push_item_add], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6"
@@ -2195,7 +2195,7 @@ def test_run_remove_noop(
         [tag_docker_push_item_remove_src], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()
@@ -2255,7 +2255,7 @@ def test_run_remove_untag_image(
         [tag_docker_push_item_remove_src], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()
@@ -2320,7 +2320,7 @@ def test_run_remove_manifest_list_remove_archs(
         [tag_docker_push_item_remove_src], hub, target_settings, mock_quay_api_client.return_value
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings)
+    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()


### PR DESCRIPTION
The the value was not available for the IIB operation functions,
so this parameter had to be added there as well.