### PR TITLE
Preserve stack trace of re-raised exception

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -212,7 +212,7 @@ class ContainerImagePusher:
                     if e.response.status_code == 404:
                         simple_dest_refs.append(dest_ref)
                     else:
-                        raise e
+                        raise
 
         if simple_dest_refs:
             LOG.info(

--- a/pubtools/_quay/manifest_list_merger.py
+++ b/pubtools/_quay/manifest_list_merger.py
@@ -137,7 +137,7 @@ class ManifestListMerger:
             if e.response.status_code == 404:
                 dest_manifest_list = None
             else:
-                raise e
+                raise
 
         archs_to_add = []
         manifests_to_add = []

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -267,7 +267,7 @@ class PushDocker:
                 if e.response.status_code == 404:
                     raise InvalidRepository("Repository {0} doesn't exist in Comet".format(repo))
                 else:
-                    raise e
+                    raise
 
             # Check if repo is not deprecated
             # TODO: check with Comet team if this is a reliable way of checking
@@ -286,7 +286,7 @@ class PushDocker:
                             "Repository {0} doesn't exist on stage".format(repo)
                         )
                     else:
-                        raise e
+                        raise
 
     @log_step("Generate backup mapping")
     def generate_backup_mapping(self, push_items):
@@ -326,7 +326,7 @@ class PushDocker:
                     if e.response.status_code == 404:
                         repo_data = None
                     else:
-                        raise e
+                        raise
 
                 for tag in tags:
                     # repo doesn't exist, add to rollback tags
@@ -431,10 +431,10 @@ class PushDocker:
                 operator_signature_handler.sign_operator_images(iib_results)
                 # Push index images to Quay
                 operator_pusher.push_index_images(iib_results)
-        except Exception as e:
+        except Exception:
             LOG.error("An exception has occurred during the push, starting rollback")
             self.rollback(backup_tags, rollback_tags)
-            raise e
+            raise
 
         # Return repos for UD cache flush
         repos = []

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -168,7 +168,7 @@ class TagDocker:
                 LOG.info("Image '{0}' doesn't exist".format(reference))
                 return None
             else:
-                raise e
+                raise
 
         manifest_type = manifest["mediaType"]
         if manifest_type not in [TagDocker.MANIFEST_V2S2_TYPE, TagDocker.MANIFEST_LIST_TYPE]:


### PR DESCRIPTION
'raise e' in Python 2 hides the source of original exception when
it's re-raised. Use 'raise' instead so user can locate the source
from traceback.