### PR TITLE
Add integration tests

### DIFF
--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -139,7 +139,6 @@ def verify_clear_repo_args(send_umb_msg, umb_urls, umb_cert):
             )
 
 
-# TODO: integration tests
 def clear_repositories(
     repositories,
     quay_org,

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -138,7 +138,6 @@ def verify_remove_repo_args(send_umb_msg, umb_urls, umb_cert):
             )
 
 
-# TODO: integration tests
 def remove_repositories(
     repositories,
     quay_org,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1243,3 +1243,175 @@ def tag_docker_push_item_mixed():
             "new_method": True,
         },
     )
+
+
+@pytest.fixture
+def container_multiarch_push_item_integration():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="push_item_origin",
+        repos={"test_namespace/test_repo": []},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "destination": {"tags": {"repo": ["tag1"]}},
+            "tags": {"target/repo": ["latest-test-tag"]},
+            "v_r": "1.0",
+            "pull_url": "some-registry/src/repo:1",
+            "build": {},
+        },
+    )
+
+
+@pytest.fixture
+def container_source_push_item_integration():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="push_item_origin",
+        repos={"test_namespace/test_repo": []},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "destination": {"tags": {"repo": ["tag1"]}},
+            "tags": {"target/repo": ["latest-test-tag", "1.0"]},
+            "v_r": "1.0",
+            "pull_url": "some-registry/src/repo:1",
+            "build": {"extra": {"image": {"sources_for_nvr": "some-src"}}},
+        },
+    )
+
+
+@pytest.fixture
+def src_manifest_list():
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:1111111111",
+                "platform": {"architecture": "arm64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:2222222222",
+                "platform": {"architecture": "armhfp", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:3333333333",
+                "platform": {"architecture": "ppc64le", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:5555555555",
+                "platform": {"architecture": "amd64", "os": "linux"},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def dest_manifest_list():
+    return {
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
+        "manifests": [
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:6666666666",
+                "platform": {"architecture": "arm64", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:7777777777",
+                "platform": {"architecture": "ppc64le", "os": "linux"},
+            },
+            {
+                "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+                "size": 429,
+                "digest": "sha256:8888888888",
+                "platform": {"architecture": "s390x", "os": "linux"},
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def tag_docker_push_item_add_integration():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="v1.5",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="metadata",
+        repos={"namespace/test_repo": ["v1.6"]},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "destination": {"tags": ["v1.6"]},
+            "tag_source": "v1.5",
+            "add_tags": ["v1.6"],
+            "remove_tags": [],
+            "archs": ["arm64", "amd64"],
+            "exclude_archs": False,
+            "new_method": True,
+        },
+    )
+
+
+@pytest.fixture
+def tag_docker_push_item_remove_no_src_integration():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="v1.8,v1.9",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="metadata",
+        repos={"namespace/test_repo2": []},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "destination": {"tags": []},
+            "tag_source": "",
+            "add_tags": [],
+            "remove_tags": ["v1.8"],
+            "archs": ["arm64", "amd64"],
+            "exclude_archs": False,
+            "new_method": True,
+        },
+    )

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -3,6 +3,7 @@ import pytest
 
 from pubtools._quay import exceptions
 from pubtools._quay import iib_operations
+from .utils.misc import IIBRes
 
 
 def test_verify_target_settings_success(target_settings):
@@ -45,11 +46,6 @@ def test_task_iib_add_bundles(
     mock_signature_remover,
     target_settings,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -134,11 +130,6 @@ def test_task_iib_remove_operators(
     mock_signature_remover,
     target_settings,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -219,11 +210,6 @@ def test_task_iib_build_from_scratch(
     mock_operator_signature_handler,
     target_settings,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import mock
 import pytest
@@ -7,11 +8,14 @@ from copy import deepcopy
 from pubtools._quay.push_docker import PushDocker
 from pubtools._quay.tag_docker import TagDocker
 from pubtools._quay import iib_operations
+from pubtools._quay import clear_repo
+from pubtools._quay import remove_repo
 from .utils.misc import sort_dictionary_sortable_values, compare_logs, IIBRes
 
 # flake8: noqa: E501
 
 
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
@@ -27,6 +31,7 @@ def test_push_docker_multiarch_merge_ml_operator(
     mock_run_cmd,
     mock_send_umb_message,
     mock_run_entrypoint_operator_pusher,
+    run_entrypoint_signature_remover,
     target_settings,
     container_multiarch_push_item_integration,
     operator_push_item_ok,
@@ -36,7 +41,13 @@ def test_push_docker_multiarch_merge_ml_operator(
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -63,6 +74,40 @@ def test_push_docker_multiarch_merge_ml_operator(
                 "sig_key_id": "some-key",
             }
         ],
+        # pubtools-pyxis-get-signatures (containers) (removing signatures)
+        [
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:6666666666",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id1",
+            },
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:7777777777",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id2",
+            },
+        ],
+        # pubtools-pyxis-get-signatures (operators) (removing signatures)
+        [
+            {
+                "reference": "registry.com/namespace/operators----index-image:v4.6",
+                "manifest_digest": "sha256:8888888888",
+                "sig_key_id": "some-key",
+                "repository": "operators/index-image",
+                "_id": "some-id1",
+            },
+            {
+                "reference": "registry.com/namespace/operators----index-image:v4.5",
+                "manifest_digest": "sha256:6666666666",
+                "sig_key_id": "some-key",
+                "repository": "operators/index-image",
+                "_id": "some-id2",
+            },
+        ],
     ]
     mock_run_entrypoint_operator_pusher.side_effect = [
         # pubtools-pyxis-get-operator-indices
@@ -79,16 +124,16 @@ def test_push_docker_multiarch_merge_ml_operator(
         ),
     ]
 
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/stage-namespace/test_namespace----test_repo/tags/list",
             json={"some-data": "value"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
-            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+            "https://quay.io/v2/some-namespace/target----repo/tags/list",
+            json={"name": "target-repo", "tags": ["latest-test-tag"]},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
@@ -106,18 +151,39 @@ def test_push_docker_multiarch_merge_ml_operator(
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            [
+                {
+                    "text": json.dumps(dest_manifest_list, sort_keys=True),
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+                {
+                    "json": dest_manifest_list,
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+            ],
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:9daac465523ce42a89e605151734e7b92c5ade2123055a6a2aeabbf60e5edfa4",
             json=dest_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
-        m.put(
-            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        m.get(
+            "https://quay.io/v2/some-namespace/operators----index-image/manifests/v4.5",
+            json=dest_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
         m.get(
-            "https://git-server.com/v4_5.yml/raw?ref=master",
+            "https://quay.io/v2/some-namespace/operators----index-image/manifests/v4.6",
+            json=dest_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
-        m.get(
-            "https://git-server.com/v4_6.yml/raw?ref=master",
-        )
+        m.put("https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag")
+        m.get("https://git-server.com/v4_5.yml/raw?ref=master")
+        m.get("https://git-server.com/v4_6.yml/raw?ref=master")
         m.get(
             "https://quay.io/v2/namespace/iib/manifests/sha256:a1a1a1",
             json=src_manifest_list,
@@ -128,6 +194,8 @@ def test_push_docker_multiarch_merge_ml_operator(
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
+        m.delete("https://pyxis-url.com/v1/signatures/id/some-id1")
+        m.delete("https://pyxis-url.com/v1/signatures/id/some-id2")
 
         push_docker = PushDocker(
             [container_multiarch_push_item_integration, operator_push_item_ok],
@@ -140,6 +208,7 @@ def test_push_docker_multiarch_merge_ml_operator(
         push_docker.run()
 
 
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
@@ -153,6 +222,7 @@ def test_push_docker_multiarch_simple_workflow(
     mock_proton,
     mock_run_cmd,
     mock_send_umb_message,
+    run_entrypoint_signature_remover,
     target_settings,
     container_multiarch_push_item_integration,
     src_manifest_list,
@@ -160,7 +230,13 @@ def test_push_docker_multiarch_simple_workflow(
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -179,18 +255,35 @@ def test_push_docker_multiarch_simple_workflow(
         ],
         # pubtools-pyxis-upload-signatures
         [],
+        # pubtools-pyxis-get-signatures (containers) (removing signatures)
+        [
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:6666666666",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id1",
+            },
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:7777777777",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id2",
+            },
+        ],
     ]
 
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/stage-namespace/test_namespace----test_repo/tags/list",
             json={"some-data": "value"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
-            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+            "https://quay.io/v2/some-namespace/target----repo/tags/list",
+            json={"name": "target-repo", "tags": ["latest-test-tag"]},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
@@ -208,6 +301,23 @@ def test_push_docker_multiarch_simple_workflow(
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            [
+                {
+                    "text": json.dumps(src_manifest_list, sort_keys=True),
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+                {
+                    "json": src_manifest_list,
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+            ],
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:8ce181d89b7bb7f1639d8df3d65d630b1322d0bb6daff5c492eec24ec53628d5",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -226,6 +336,7 @@ def test_push_docker_multiarch_simple_workflow(
         push_docker.run()
 
 
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
@@ -239,6 +350,7 @@ def test_push_docker_source(
     mock_proton,
     mock_run_cmd,
     mock_send_umb_message,
+    run_entrypoint_signature_remover,
     target_settings,
     container_source_push_item_integration,
     src_manifest_list,
@@ -246,7 +358,13 @@ def test_push_docker_source(
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -265,18 +383,35 @@ def test_push_docker_source(
         ],
         # pubtools-pyxis-upload-signatures
         [],
+        # pubtools-pyxis-get-signatures (containers) (removing signatures)
+        [
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:6666666666",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id1",
+            },
+            {
+                "reference": "registry.com/namespace/target----repo:latest-test-tag",
+                "manifest_digest": "sha256:7777777777",
+                "sig_key_id": "some-key",
+                "repository": "target/repo",
+                "_id": "some-id2",
+            },
+        ],
     ]
 
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/stage-namespace/test_namespace----test_repo/tags/list",
             json={"some-data": "value"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
-            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+            "https://quay.io/v2/some-namespace/target----repo/tags/list",
+            json={"name": "target-repo", "tags": ["latest-test-tag"]},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
@@ -294,6 +429,23 @@ def test_push_docker_source(
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            [
+                {
+                    "text": json.dumps(src_manifest_list, sort_keys=True),
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+                {
+                    "json": src_manifest_list,
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+            ],
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:8ce181d89b7bb7f1639d8df3d65d630b1322d0bb6daff5c492eec24ec53628d5",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -312,6 +464,7 @@ def test_push_docker_source(
         push_docker.run()
 
 
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
@@ -325,6 +478,7 @@ def test_push_docker_multiarch_rollback(
     mock_proton,
     mock_run_cmd,
     mock_send_umb_message,
+    run_entrypoint_signature_remover,
     target_settings,
     container_multiarch_push_item_integration,
     src_manifest_list,
@@ -332,7 +486,13 @@ def test_push_docker_multiarch_rollback(
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -357,12 +517,12 @@ def test_push_docker_multiarch_rollback(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/stage-namespace/test_namespace----test_repo/tags/list",
             json={"some-data": "value"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
-            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+            "https://quay.io/v2/some-namespace/target----repo/tags/list",
+            json={"name": "target-repo", "tags": ["latest-test-tag"]},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
@@ -380,11 +540,28 @@ def test_push_docker_multiarch_rollback(
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
-            json=src_manifest_list,
-            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+            [
+                {
+                    "text": json.dumps(src_manifest_list, sort_keys=True),
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+                {
+                    "json": src_manifest_list,
+                    "headers": {
+                        "Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"
+                    },
+                },
+            ],
         )
         m.put(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:8ce181d89b7bb7f1639d8df3d65d630b1322d0bb6daff5c492eec24ec53628d5",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
 
         push_docker = PushDocker(
@@ -400,11 +577,13 @@ def test_push_docker_multiarch_rollback(
 
 
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.push_docker.run_entrypoint")
 def test_tag_docker_multiarch_merge_ml(
     mock_run_entrypoint_push_docker,
     mock_run_entrypoint_sig_handler,
+    mock_run_entrypoint_sig_remover,
     mock_claims_handler,
     target_settings,
     tag_docker_push_item_add_integration,
@@ -413,7 +592,13 @@ def test_tag_docker_multiarch_merge_ml(
 ):
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -436,6 +621,27 @@ def test_tag_docker_multiarch_merge_ml(
         # pubtools-pyxis-upload-signatures
         [],
     ]
+    mock_run_entrypoint_sig_remover.side_effect = [
+        # pubtools-pyxis-get-signatures (removing signatures)
+        [
+            {
+                "reference": "registry.com/namespace/namespace----test_repo:v1.6",
+                "manifest_digest": "sha256:1111111111",
+                "sig_key_id": "some-key",
+                "repository": "namespace/test_repo",
+                "_id": "some-id1",
+            },
+            {
+                "reference": "registry.com/namespace/namespace----test_repo:v1.6",
+                "manifest_digest": "sha256:2222222222",
+                "sig_key_id": "some-key",
+                "repository": "namespace/test_repo",
+                "_id": "some-id2",
+            },
+        ],
+        # pubtools-pyxis-delete-signatures
+        [],
+    ]
 
     src_manifest_list_missing = deepcopy(src_manifest_list)
     src_manifest_list_missing["manifests"] = src_manifest_list_missing["manifests"][:2]
@@ -448,21 +654,43 @@ def test_tag_docker_multiarch_merge_ml(
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/stage-namespace/namespace----test_repo/tags/list",
             json={
-                "tags": {
-                    "v1.5": {"manifest_digest": "a1a1a1"},
-                    "v1.6": {"manifest_digest": "b2b2b2"},
-                }
+                "name": "namespace----test_repo",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
             },
         )
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo2?includeTags=True",
+            "https://quay.io/v2/some-namespace/namespace----test_repo/tags/list",
             json={
-                "tags": {
-                    "v1.5": {"manifest_digest": "a1a1a1"},
-                    "v1.6": {"manifest_digest": "b2b2b2"},
-                }
+                "name": "namespace----test_repo",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo2/tags/list",
+            json={
+                "name": "namespace----test_repo2",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/tags/list",
+            json={
+                "name": "namespace----test_repo2",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
             },
         )
         m.get(
@@ -519,11 +747,13 @@ def test_tag_docker_multiarch_merge_ml(
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.push_docker.run_entrypoint")
 def test_tag_docker_source_copy_untag(
     mock_run_entrypoint_push_docker,
     mock_run_entrypoint_sig_handler,
+    mock_run_entrypoint_sig_remover,
     mock_claims_handler,
     mock_run_cmd,
     mock_send_umb_message_tag,
@@ -535,7 +765,13 @@ def test_tag_docker_source_copy_untag(
 ):
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
-    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    mock_get_target_info.return_value = {
+        "settings": {
+            "quay_namespace": "stage-namespace",
+            "dest_quay_user": "stage-user",
+            "dest_quay_password": "stage-password",
+        }
+    }
     hub.worker.get_target_info = mock_get_target_info
     target_settings["propagated_from"] = "test-target"
 
@@ -559,7 +795,17 @@ def test_tag_docker_source_copy_untag(
         [],
     ]
 
-    mock_run_cmd.return_value = ('{"Architecture": "amd64"}', "err")
+    mock_run_cmd.side_effect = [
+        ("Login Succeeded", "err"),
+        ("Login Succeeded", "err"),
+        ('{"Architecture": "amd64"}', "err"),
+        ('{"Architecture": "amd64"}', "err"),
+        ('{"Architecture": "amd64"}', "err"),
+        ("Login Succeeded", "err"),
+        ("Login Succeeded", "err"),
+        None,
+        ('{"Architecture": "amd64"}', "err"),
+    ]
 
     with requests_mock.Mocker() as m:
 
@@ -569,21 +815,53 @@ def test_tag_docker_source_copy_untag(
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
         )
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo?includeTags=True",
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.5",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.6",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo/tags/list",
             json={
-                "tags": {
-                    "v1.5": {"manifest_digest": "a1a1a1"},
-                    "v1.6": {"manifest_digest": "b2b2b2"},
-                }
+                "name": "namespace----test_repo",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
             },
         )
         m.get(
-            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo2?includeTags=True",
+            "https://quay.io/v2/some-namespace/namespace----test_repo/tags/list",
             json={
-                "tags": {
-                    "v1.5": {"manifest_digest": "a1a1a1"},
-                    "v1.6": {"manifest_digest": "b2b2b2"},
-                }
+                "name": "namespace----test_repo",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo2/tags/list",
+            json={
+                "name": "namespace----test_repo2",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/tags/list",
+            json={
+                "name": "namespace----test_repo2",
+                "tags": [
+                    "v1.5",
+                    "v1.6",
+                ],
             },
         )
         m.get(
@@ -641,6 +919,7 @@ def test_tag_docker_source_copy_untag(
 
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
@@ -648,6 +927,7 @@ def test_task_iib_add_bundles(
     mock_run_entrypoint_operator_pusher,
     mock_manifest_claims_handler,
     mock_run_entrypoint_signature_handler,
+    mock_run_entrypoint_signature_remover,
     mock_run_cmd,
     mock_send_umb_message,
     target_settings,
@@ -663,13 +943,35 @@ def test_task_iib_add_bundles(
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/operators----index-image:8",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "operators/index-image",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/operators----index-image:8",
+            "manifest_digest": "sha256:2222222222",
+            "sig_key_id": "some-key",
+            "repository": "operators/index-image",
+            "_id": "some-id2",
+        },
+    ]
 
     mock_hub = mock.MagicMock()
 
     with requests_mock.Mocker() as m:
         m.get(
             "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/operators----index-image/manifests/8",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -689,6 +991,7 @@ def test_task_iib_add_bundles(
 
 @mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
@@ -696,6 +999,7 @@ def test_task_iib_remove_operators(
     mock_run_entrypoint_operator_pusher,
     mock_manifest_claims_handler,
     mock_run_entrypoint_signature_handler,
+    mock_run_entrypoint_signature_remover,
     mock_run_cmd,
     mock_send_umb_message,
     target_settings,
@@ -706,13 +1010,36 @@ def test_task_iib_remove_operators(
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/operators----index-image:8",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "operators/index-image",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/operators----index-image:8",
+            "manifest_digest": "sha256:2222222222",
+            "sig_key_id": "some-key",
+            "repository": "operators/index-image",
+            "_id": "some-id2",
+        },
+    ]
 
     mock_hub = mock.MagicMock()
 
     with requests_mock.Mocker() as m:
         m.get(
             "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        m.get(
+            "https://quay.io/v2/some-namespace/operators----index-image/manifests/8",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -748,7 +1075,7 @@ def test_task_iib_build_from_scratch(
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
-    mock_run_cmd.return_value = ("out", "err")
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
 
     mock_hub = mock.MagicMock()
 
@@ -768,4 +1095,397 @@ def test_task_iib_build_from_scratch(
             "1",
             target_settings,
             "some-target",
+        )
+
+
+@mock.patch("pubtools._quay.untag_images.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
+def test_clear_repo(
+    mock_run_entrypoint_signature_remover,
+    mock_send_umb_message_clear_repo,
+    mock_send_umb_message_untag_images,
+    src_manifest_list,
+):
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/namespace----repo1:1",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/namespace----repo1-image:2",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id2",
+        },
+    ]
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "1",
+                    "2",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "3",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/2",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/manifests/3",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/1",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/2",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo2/tag/3",
+        )
+
+        clear_repo.clear_repositories(
+            repositories="namespace/repo1,namespace/repo2",
+            quay_org="some-org",
+            quay_api_token="some-api-token",
+            quay_user="some-user",
+            quay_password="some-password",
+            pyxis_server="pyxis-server.com",
+            pyxis_krb_principal="some-principal@REDHAT.COM",
+            pyxis_krb_ktfile="path/to/file",
+            send_umb_msg=True,
+            umb_urls=["url1.com", "url2.com"],
+            umb_cert="some/path.crt",
+            umb_client_key="some/path.key",
+            umb_ca_cert="cacert/path.crt",
+        )
+
+
+@mock.patch("pubtools._quay.untag_images.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
+def test_clear_repo(
+    mock_run_entrypoint_signature_remover,
+    mock_send_umb_message_clear_repo,
+    mock_send_umb_message_untag_images,
+    src_manifest_list,
+):
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/namespace----repo1:1",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/namespace----repo1-image:2",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id2",
+        },
+    ]
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "1",
+                    "2",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "3",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/2",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/manifests/3",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/1",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/2",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo2/tag/3",
+        )
+
+        clear_repo.clear_repositories(
+            repositories="namespace/repo1,namespace/repo2",
+            quay_org="some-org",
+            quay_api_token="some-api-token",
+            quay_user="some-user",
+            quay_password="some-password",
+            pyxis_server="pyxis-server.com",
+            pyxis_krb_principal="some-principal@REDHAT.COM",
+            pyxis_krb_ktfile="path/to/file",
+            send_umb_msg=True,
+            umb_urls=["url1.com", "url2.com"],
+            umb_cert="some/path.crt",
+            umb_client_key="some/path.key",
+            umb_ca_cert="cacert/path.crt",
+        )
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_task_iib_build_from_scratch(
+    mock_run_entrypoint_operator_pusher,
+    mock_manifest_claims_handler,
+    mock_run_entrypoint_signature_handler,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    src_manifest_list,
+):
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
+    mock_run_entrypoint_operator_pusher.return_value = build_details
+    mock_run_cmd.return_value = ("Login Succeeded", "err")
+
+    mock_hub = mock.MagicMock()
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        iib_operations.task_iib_build_from_scratch(
+            ["bundle1", "bundle2"],
+            ["arch1", "arch2"],
+            "12",
+            ["some-key"],
+            mock_hub,
+            "1",
+            target_settings,
+            "some-target",
+        )
+
+
+@mock.patch("pubtools._quay.untag_images.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
+def test_clear_repo(
+    mock_run_entrypoint_signature_remover,
+    mock_send_umb_message_clear_repo,
+    mock_send_umb_message_untag_images,
+    src_manifest_list,
+):
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/namespace----repo1:1",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/namespace----repo1-image:2",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id2",
+        },
+    ]
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "1",
+                    "2",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "3",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/2",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/manifests/3",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/1",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1/tag/2",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo2/tag/3",
+        )
+
+        clear_repo.clear_repositories(
+            repositories="namespace/repo1,namespace/repo2",
+            quay_org="some-org",
+            quay_api_token="some-api-token",
+            quay_user="some-user",
+            quay_password="some-password",
+            pyxis_server="pyxis-server.com",
+            pyxis_krb_principal="some-principal@REDHAT.COM",
+            pyxis_krb_ktfile="path/to/file",
+            send_umb_msg=True,
+            umb_urls=["url1.com", "url2.com"],
+            umb_cert="some/path.crt",
+            umb_client_key="some/path.key",
+            umb_ca_cert="cacert/path.crt",
+        )
+
+
+@mock.patch("pubtools._quay.remove_repo.send_umb_message")
+@mock.patch("pubtools._quay.signature_remover.run_entrypoint")
+def test_remove_repo(
+    mock_run_entrypoint_signature_remover,
+    mock_send_umb_message_clear_repo,
+    src_manifest_list,
+):
+
+    mock_run_entrypoint_signature_remover.return_value = [
+        {
+            "reference": "registry.com/namespace/namespace----repo1:1",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id1",
+        },
+        {
+            "reference": "registry.com/namespace/namespace----repo1-image:2",
+            "manifest_digest": "sha256:1111111111",
+            "sig_key_id": "some-key",
+            "repository": "namespace/repo1",
+            "_id": "some-id2",
+        },
+    ]
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "1",
+                    "2",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/tags/list",
+            json={
+                "name": "namespace----repo1",
+                "tags": [
+                    "3",
+                ],
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo1/manifests/2",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-org/namespace----repo2/manifests/3",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo1",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-org/namespace----repo2",
+        )
+
+        remove_repo.remove_repositories(
+            repositories="namespace/repo1,namespace/repo2",
+            quay_org="some-org",
+            quay_api_token="some-api-token",
+            quay_user="some-user",
+            quay_password="some-password",
+            pyxis_server="pyxis-server.com",
+            pyxis_krb_principal="some-principal@REDHAT.COM",
+            pyxis_krb_ktfile="path/to/file",
+            send_umb_msg=True,
+            umb_urls=["url1.com", "url2.com"],
+            umb_cert="some/path.crt",
+            umb_client_key="some/path.key",
+            umb_ca_cert="cacert/path.crt",
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,801 @@
+import logging
+import mock
+import pytest
+import requests_mock
+from copy import deepcopy
+
+from pubtools._quay.push_docker import PushDocker
+from pubtools._quay.tag_docker import TagDocker
+from pubtools._quay import iib_operations
+from .utils.misc import sort_dictionary_sortable_values, compare_logs
+
+# flake8: noqa: E501
+
+
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.proton")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_push_docker_multiarch_merge_ml_operator(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    mock_proton,
+    mock_run_cmd,
+    mock_send_umb_message,
+    mock_run_entrypoint_operator_pusher,
+    target_settings,
+    container_multiarch_push_item_integration,
+    operator_push_item_ok,
+    src_manifest_list,
+    dest_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    # hub usage has to be mocked
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        [],
+        # pubtools-pyxis-get-signatures (operators)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+    ]
+    mock_run_entrypoint_operator_pusher.side_effect = [
+        # pubtools-pyxis-get-operator-indices
+        [{"ocp_version": "4.5"}, {"ocp_version": "4.6"}],
+        # pubtools-iib-add-bundles (4.5)
+        IIBRes(
+            "registry.com/namespace/index-image@sha256:v4.5",
+            "registry.com/namespace/index-image@sha256:a1a1a1",
+        ),
+        # pubtools-iib-add-bundles (4.6)
+        IIBRes(
+            "registry.com/namespace/index-image@sha256:v4.6",
+            "registry.com/namespace/index-image@sha256:b2b2b2",
+        ),
+    ]
+
+    mock_run_cmd.return_value = ("out", "err")
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            json={"some-data": "value"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
+            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
+            json={"mediaType": "manifest"},
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/src/repo?includeTags=True",
+            json={"tags": {"1": {"image_id": None}}},
+        )
+        m.get(
+            "https://quay.io/v2/src/repo/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            json=dest_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        )
+        m.get(
+            "https://git-server.com/v4_5.yml/raw?ref=master",
+        )
+        m.get(
+            "https://git-server.com/v4_6.yml/raw?ref=master",
+        )
+        m.get(
+            "https://quay.io/v2/namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/namespace/iib/manifests/sha256:b2b2b2",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        push_docker = PushDocker(
+            [container_multiarch_push_item_integration, operator_push_item_ok],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        push_docker.run()
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.proton")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_push_docker_multiarch_simple_workflow(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    mock_proton,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    container_multiarch_push_item_integration,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    # hub usage has to be mocked
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        [],
+    ]
+
+    mock_run_cmd.return_value = ("out", "err")
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            json={"some-data": "value"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
+            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
+            json={"mediaType": "manifest"},
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/src/repo?includeTags=True",
+            json={"tags": {"1": {"image_id": None}}},
+        )
+        m.get(
+            "https://quay.io/v2/src/repo/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        )
+
+        push_docker = PushDocker(
+            [container_multiarch_push_item_integration],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        push_docker.run()
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.proton")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_push_docker_source(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    mock_proton,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    container_source_push_item_integration,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    # hub usage has to be mocked
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        [],
+    ]
+
+    mock_run_cmd.return_value = ("out", "err")
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            json={"some-data": "value"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
+            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
+            json={"mediaType": "manifest"},
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/src/repo?includeTags=True",
+            json={"tags": {"1": {"image_id": None}}},
+        )
+        m.get(
+            "https://quay.io/v2/src/repo/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        )
+
+        push_docker = PushDocker(
+            [container_source_push_item_integration],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        push_docker.run()
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.proton")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_push_docker_multiarch_rollback(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    mock_proton,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    container_multiarch_push_item_integration,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    # hub usage has to be mocked
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        ValueError("something went wrong"),
+    ]
+
+    mock_run_cmd.return_value = ("out", "err")
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/test_namespace----test_repo?includeTags=True",
+            json={"some-data": "value"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/target----repo?includeTags=True",
+            json={"tags": {"latest-test-tag": {"manifest_digest": "a1a1a1"}}},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/a1a1a1",
+            json={"mediaType": "manifest"},
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/src/repo?includeTags=True",
+            json={"tags": {"1": {"image_id": None}}},
+        )
+        m.get(
+            "https://quay.io/v2/src/repo/manifests/1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+        )
+
+        push_docker = PushDocker(
+            [container_multiarch_push_item_integration],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        with pytest.raises(ValueError, match="something went wrong"):
+            push_docker.run()
+
+
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_tag_docker_multiarch_merge_ml(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    target_settings,
+    tag_docker_push_item_add_integration,
+    tag_docker_push_item_remove_no_src_integration,
+    src_manifest_list,
+):
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        [],
+    ]
+
+    src_manifest_list_missing = deepcopy(src_manifest_list)
+    src_manifest_list_missing["manifests"] = src_manifest_list_missing["manifests"][:2]
+
+    with requests_mock.Mocker() as m:
+
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.5",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo2?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo/manifests/v1.6",
+            json=src_manifest_list_missing,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo2/manifests/v1.8",
+            status_code=404,
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/namespace----test_repo?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.6",
+            json=src_manifest_list_missing,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.6",
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.8",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/namespace----test_repo2?includeTags=True",
+            json={"tags": {"v1.8": {"manifest_digest": "c3c3c3"}}},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.8",
+        )
+
+        tag_docker_instance = TagDocker(
+            [tag_docker_push_item_add_integration, tag_docker_push_item_remove_no_src_integration],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        tag_docker_instance.run()
+
+
+@mock.patch("pubtools._quay.untag_images.send_umb_message")
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.push_docker.run_entrypoint")
+def test_tag_docker_source_copy_untag(
+    mock_run_entrypoint_push_docker,
+    mock_run_entrypoint_sig_handler,
+    mock_claims_handler,
+    mock_run_cmd,
+    mock_send_umb_message_tag,
+    mock_send_umb_message_untag,
+    target_settings,
+    tag_docker_push_item_add_integration,
+    tag_docker_push_item_remove_no_src_integration,
+    v2s2_manifest_data,
+):
+    hub = mock.MagicMock()
+    mock_get_target_info = mock.MagicMock()
+    mock_get_target_info.return_value = {"settings": {"quay_namespace": "stage-namespace"}}
+    hub.worker.get_target_info = mock_get_target_info
+    target_settings["propagated_from"] = "test-target"
+
+    mock_run_entrypoint_push_docker.side_effect = [
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+        # pubtools-pyxis-get-repo-metadata
+        {"release_categories": ["definitely-not-deprecated"]},
+    ]
+
+    mock_run_entrypoint_sig_handler.side_effect = [
+        # pubtools-pyxis-get-signatures (containers)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures
+        [],
+    ]
+
+    mock_run_cmd.return_value = ('{"Architecture": "amd64"}', "err")
+
+    with requests_mock.Mocker() as m:
+
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.5",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/stage-namespace/namespace----test_repo2?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo/manifests/v1.6",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/stage-namespace/namespace----test_repo2/manifests/v1.8",
+            status_code=404,
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/namespace----test_repo?includeTags=True",
+            json={
+                "tags": {
+                    "v1.5": {"manifest_digest": "a1a1a1"},
+                    "v1.6": {"manifest_digest": "b2b2b2"},
+                }
+            },
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.6",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/namespace----test_repo/manifests/v1.6",
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.8",
+            json=v2s2_manifest_data,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        )
+        m.get(
+            "https://quay.io/api/v1/repository/some-namespace/namespace----test_repo2?includeTags=True",
+            json={"tags": {"v1.8": {"manifest_digest": "c3c3c3", "image_id": "some-id"}}},
+        )
+        m.put(
+            "https://quay.io/v2/some-namespace/namespace----test_repo2/manifests/v1.8",
+        )
+        m.delete(
+            "https://quay.io/api/v1/repository/some-namespace/namespace----test_repo2/tag/v1.8",
+        )
+
+        tag_docker_instance = TagDocker(
+            [tag_docker_push_item_add_integration, tag_docker_push_item_remove_no_src_integration],
+            hub,
+            "1",
+            "some-target",
+            target_settings,
+        )
+
+        tag_docker_instance.run()
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_task_iib_add_bundles(
+    mock_run_entrypoint_operator_pusher,
+    mock_manifest_claims_handler,
+    mock_run_entrypoint_signature_handler,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
+    mock_run_entrypoint_operator_pusher.return_value = build_details
+    mock_run_cmd.return_value = ("out", "err")
+
+    mock_hub = mock.MagicMock()
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        iib_operations.task_iib_add_bundles(
+            ["bundle1", "bundle2"],
+            ["arch1", "arch2"],
+            "some-registry.com/redhat-namespace/new-index-image:5",
+            ["bundle3", "bundle4"],
+            ["some-key"],
+            mock_hub,
+            "1",
+            target_settings,
+            "some-target",
+        )
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_task_iib_remove_operators(
+    mock_run_entrypoint_operator_pusher,
+    mock_manifest_claims_handler,
+    mock_run_entrypoint_signature_handler,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
+    mock_run_entrypoint_operator_pusher.return_value = build_details
+    mock_run_cmd.return_value = ("out", "err")
+
+    mock_hub = mock.MagicMock()
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        iib_operations.task_iib_remove_operators(
+            ["operator1", "operator2"],
+            ["arch1", "arch2"],
+            "some-registry.com/redhat-namespace/new-index-image:5",
+            ["some-key"],
+            mock_hub,
+            "1",
+            target_settings,
+            "some-target",
+        )
+
+
+@mock.patch("pubtools._quay.tag_images.send_umb_message")
+@mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
+@mock.patch("pubtools._quay.signature_handler.run_entrypoint")
+@mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+def test_task_iib_build_from_scratch(
+    mock_run_entrypoint_operator_pusher,
+    mock_manifest_claims_handler,
+    mock_run_entrypoint_signature_handler,
+    mock_run_cmd,
+    mock_send_umb_message,
+    target_settings,
+    src_manifest_list,
+):
+    class IIBRes:
+        def __init__(self, index_image, index_image_resolved):
+            self.index_image = index_image
+            self.index_image_resolved = index_image_resolved
+
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+    )
+    mock_run_entrypoint_operator_pusher.return_value = build_details
+    mock_run_cmd.return_value = ("out", "err")
+
+    mock_hub = mock.MagicMock()
+
+    with requests_mock.Mocker() as m:
+        m.get(
+            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            json=src_manifest_list,
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+
+        iib_operations.task_iib_build_from_scratch(
+            ["bundle1", "bundle2"],
+            ["arch1", "arch2"],
+            "12",
+            ["some-key"],
+            mock_hub,
+            "1",
+            target_settings,
+            "some-target",
+        )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from pubtools._quay.push_docker import PushDocker
 from pubtools._quay.tag_docker import TagDocker
 from pubtools._quay import iib_operations
-from .utils.misc import sort_dictionary_sortable_values, compare_logs
+from .utils.misc import sort_dictionary_sortable_values, compare_logs, IIBRes
 
 # flake8: noqa: E501
 
@@ -33,11 +33,6 @@ def test_push_docker_multiarch_merge_ml_operator(
     src_manifest_list,
     dest_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
@@ -162,11 +157,6 @@ def test_push_docker_multiarch_simple_workflow(
     container_multiarch_push_item_integration,
     src_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
@@ -253,11 +243,6 @@ def test_push_docker_source(
     container_source_push_item_integration,
     src_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
@@ -344,11 +329,6 @@ def test_push_docker_multiarch_rollback(
     container_multiarch_push_item_integration,
     src_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     # hub usage has to be mocked
     hub = mock.MagicMock()
     mock_get_target_info = mock.MagicMock()
@@ -721,11 +701,6 @@ def test_task_iib_remove_operators(
     target_settings,
     src_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -768,11 +743,6 @@ def test_task_iib_build_from_scratch(
     target_settings,
     src_manifest_list,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -102,3 +102,9 @@ def mock_entry_point(dist, group, name):
         yield new_mock
     finally:
         override.stop()
+
+
+class IIBRes:
+    def __init__(self, index_image, index_image_resolved):
+        self.index_image = index_image
+        self.index_image_resolved = index_image_resolved


### PR DESCRIPTION
The new tests only mock the necessary components that exist outside
of pubtools-quay. The inter-project calls are preserved, allowing
for a detection of method header change issues.