### PR TITLE
Add entrypoint for clearing a Quay repo 

### DIFF
--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -20,8 +20,8 @@ CLEAR_REPO_ARGS = {
         "required": True,
         "type": str,
     },
-    ("--namespace",): {
-        "help": "Internal Quay namespace in which repository resides.",
+    ("--quay-org",): {
+        "help": "Quay organization in which repository resides.",
         "required": True,
         "type": str,
     },
@@ -147,7 +147,7 @@ def verify_clear_repo_args(repository, send_umb_msg, umb_urls, umb_cert):
 # TODO: integration tests
 def clear_repository(
     repository,
-    namespace,
+    quay_org,
     quay_api_token,
     quay_user,
     quay_password,
@@ -167,8 +167,8 @@ def clear_repository(
     Args:
         repository (str):
             External repository to clear.
-        namespace (str):
-            Internal Quay namespace in which repository resides.
+        quay_org (str):
+            Quay organization in which repository resides.
         quay_api_token (str):
             OAuth token for authentication of Quay REST API.
         quay_user (str):
@@ -202,17 +202,17 @@ def clear_repository(
     sig_remover = SignatureRemover(quay_user=quay_user, quay_password=quay_password)
     sig_remover.set_quay_api_client(quay_api_client)
     sig_remover.remove_repository_signatures(
-        repository, namespace, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
+        repository, quay_org, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
     )
 
-    internal_repo = "{0}/{1}".format(namespace, get_internal_container_repo_name(repository))
+    internal_repo = "{0}/{1}".format(quay_org, get_internal_container_repo_name(repository))
     repo_data = quay_api_client.get_repository_data(internal_repo)
     refrences_to_remove = []
     for tag in repo_data["tags"]:
         refrences_to_remove.append("{0}/{1}:{2}".format("quay.io", internal_repo, tag))
 
     untag_images(
-        refrences_to_remove,
+        sorted(refrences_to_remove),
         quay_api_token,
         remove_last=True,
         quay_user=quay_user,

--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -1,0 +1,256 @@
+import logging
+
+from .signature_remover import SignatureRemover
+from .quay_api_client import QuayApiClient
+from .untag_images import untag_images
+from .utils.misc import (
+    setup_arg_parser,
+    add_args_env_variables,
+    send_umb_message,
+    get_internal_container_repo_name,
+)
+
+LOG = logging.getLogger()
+logging.basicConfig()
+LOG.setLevel(logging.INFO)
+
+CLEAR_REPO_ARGS = {
+    ("--repository",): {
+        "help": "External repository to clear. Must be in format <namespace>/<repo>.",
+        "required": True,
+        "type": str,
+    },
+    ("--namespace",): {
+        "help": "Internal Quay namespace in which repository resides.",
+        "required": True,
+        "type": str,
+    },
+    ("--quay-api-token",): {
+        "help": "OAuth token for Quay REST API.",
+        "required": False,
+        "type": str,
+        "env_variable": "QUAY_API_TOKEN",
+    },
+    ("--quay-user",): {
+        "help": "Username for Quay login.",
+        "required": True,
+        "type": str,
+    },
+    ("--quay-password",): {
+        "help": "Password for Quay. Can be specified by env variable QUAY_PASSWORD.",
+        "required": False,
+        "type": str,
+        "env_variable": "QUAY_PASSWORD",
+    },
+    ("--pyxis-server",): {
+        "help": "Pyxis service hostname",
+        "required": True,
+        "type": str,
+    },
+    ("--pyxis-krb-principal",): {
+        "help": "Pyxis kerberos principal in form: name@REALM",
+        "required": True,
+        "type": str,
+    },
+    ("--pyxis-krb-ktfile",): {
+        "help": "Pyxis Kerberos client keytab. Optional. Used for login if TGT is not available.",
+        "required": False,
+        "type": str,
+    },
+    ("--send-umb-msg",): {
+        "help": "Flag of whether to send a UMB message",
+        "required": False,
+        "type": bool,
+    },
+    ("--umb-url",): {
+        "help": "UMB URL. More than one can be specified.",
+        "required": False,
+        "type": str,
+        "action": "append",
+    },
+    ("--umb-cert",): {
+        "help": "Path to the UMB certificate for SSL authentication.",
+        "required": False,
+        "type": str,
+    },
+    ("--umb-client-key",): {
+        "help": "Path to the UMB private key for accessing the certificate.",
+        "required": False,
+        "type": str,
+    },
+    ("--umb-ca-cert",): {
+        "help": "Path to the UMB CA certificate.",
+        "required": False,
+        "type": str,
+    },
+    ("--umb-topic",): {
+        "help": "UMB topic to send the message to.",
+        "required": False,
+        "type": str,
+        "default": "VirtualTopic.eng.pub.quay_clear_repository",
+    },
+}
+
+
+def construct_kwargs(args):
+    """
+    Construct a kwargs dictionary based on the entered command line arguments.
+
+    Args:
+        args (argparse.Namespace):
+            Parsed command line arguments.
+
+    Returns (dict):
+        Keyword arguments for the 'remove_repository' function.
+    """
+    kwargs = args.__dict__
+
+    # in args.__dict__ unspecified bool values have 'None' instead of 'False'
+    for name, attributes in CLEAR_REPO_ARGS.items():
+        if attributes["type"] is bool:
+            bool_var = name[0].lstrip("-").replace("-", "_")
+            if kwargs[bool_var] is None:
+                kwargs[bool_var] = False
+
+    # some exceptions have to be remapped
+    kwargs["umb_urls"] = kwargs.pop("umb_url")
+
+    return kwargs
+
+
+def verify_clear_repo_args(repository, send_umb_msg, umb_urls, umb_cert):
+    """
+    Verify the presence and correctness of input parameters.
+
+    Args:
+        repository (str):
+            Repository to remove.
+        send_umb_msg (bool):
+            Whether to send UMB messages about the untagged images.
+        umb_urls ([str]):
+            AMQP broker URLs to connect to.
+        umb_cert (str):
+            Path to a certificate used for UMB authentication.
+    """
+    if repository.count("/") != 1 or repository[0] == "/" or repository[-1] == "/":
+        raise ValueError("Provided repository must have format <namespace>/<repo>.")
+
+    if send_umb_msg:
+        if not umb_urls:
+            raise ValueError("UMB URL must be specified if sending a UMB message was requested.")
+        if not umb_cert:
+            raise ValueError(
+                "A path to a client certificate must be provided when sending a UMB message."
+            )
+
+
+# TODO: integration tests
+def clear_repository(
+    repository,
+    namespace,
+    quay_api_token,
+    quay_user,
+    quay_password,
+    pyxis_server,
+    pyxis_krb_principal,
+    pyxis_krb_ktfile,
+    send_umb_msg=False,
+    umb_urls=[],
+    umb_cert=None,
+    umb_client_key=None,
+    umb_ca_cert=None,
+    umb_topic="VirtualTopic.eng.pub.quay_clear_repository",
+):
+    """
+    Clear Quay repository.
+
+    Args:
+        repository (str):
+            External repository to clear.
+        namespace (str):
+            Internal Quay namespace in which repository resides.
+        quay_api_token (str):
+            OAuth token for authentication of Quay REST API.
+        quay_user (str):
+            Quay username for Docker HTTP API.
+        quay_password (str):
+            Quay password for Docker HTTP API.
+        pyxis_server (str):
+            Pyxis service hostname:
+        pyxis_krb_principal (str):
+            Pyxis kerberos principal in form: name@REALM.
+        pyxis_krb_ktfile (str):
+            Pyxis Kerberos client keytab.
+        send_umb_msg (bool):
+            Whether to send UMB messages about the untagged images.
+        umb_urls ([str]):
+            AMQP broker URLs to connect to.
+        umb_cert (str):
+            Path to a certificate used for UMB authentication.
+        umb_client_key (str):
+            Path to a client key to decrypt the certificate (if necessary).
+        umb_ca_cert (str):
+            Path to a CA certificate (for mutual authentication).
+        umb_topic (str):
+            Topic to send the UMB messages to.
+    """
+    verify_clear_repo_args(repository, send_umb_msg, umb_urls, umb_cert)
+
+    LOG.info("Clearing repository '{0}'".format(repository))
+    quay_api_client = QuayApiClient(quay_api_token)
+
+    sig_remover = SignatureRemover(quay_user=quay_user, quay_password=quay_password)
+    sig_remover.set_quay_api_client(quay_api_client)
+    sig_remover.remove_repository_signatures(
+        repository, namespace, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
+    )
+
+    internal_repo = "{0}/{1}".format(namespace, get_internal_container_repo_name(repository))
+    repo_data = quay_api_client.get_repository_data(internal_repo)
+    refrences_to_remove = []
+    for tag in repo_data["tags"]:
+        refrences_to_remove.append("{0}/{1}:{2}".format("quay.io", internal_repo, tag))
+
+    untag_images(
+        refrences_to_remove,
+        quay_api_token,
+        remove_last=True,
+        quay_user=quay_user,
+        quay_password=quay_password,
+        send_umb_msg=send_umb_msg,
+        umb_urls=umb_urls,
+        umb_cert=umb_cert,
+        umb_client_key=umb_client_key,
+        umb_ca_cert=umb_ca_cert,
+    )
+
+    LOG.info("Repository has been cleared")
+    if send_umb_msg:
+        LOG.info("Sending a UMB message")
+        props = {"cleared_repository": repository}
+        send_umb_message(
+            umb_urls,
+            props,
+            umb_cert,
+            umb_topic,
+            client_key=umb_client_key,
+            ca_cert=umb_ca_cert,
+        )
+
+
+def clear_repository_main(sysargs=None):
+    """Entrypoint for clearing a repository."""
+    parser = setup_arg_parser(CLEAR_REPO_ARGS)
+    if sysargs:
+        args = parser.parse_args(sysargs[1:])
+    else:
+        args = parser.parse_args()  # pragma: no cover"
+    args = add_args_env_variables(args, CLEAR_REPO_ARGS)
+
+    if not args.quay_api_token:
+        raise ValueError("--quay-api-token must be specified")
+    if not args.quay_password:
+        raise ValueError("--quay-password must be specified")
+
+    kwargs = construct_kwargs(args)
+    clear_repository(**kwargs)

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -19,8 +19,8 @@ REMOVE_REPO_ARGS = {
         "required": True,
         "type": str,
     },
-    ("--namespace",): {
-        "help": "Internal Quay namespace in which repository resides.",
+    ("--quay-org",): {
+        "help": "Quay organization in which repository resides.",
         "required": True,
         "type": str,
     },
@@ -146,7 +146,7 @@ def verify_remove_repo_args(repository, send_umb_msg, umb_urls, umb_cert):
 # TODO: integration tests
 def remove_repository(
     repository,
-    namespace,
+    quay_org,
     quay_api_token,
     quay_user,
     quay_password,
@@ -166,8 +166,8 @@ def remove_repository(
     Args:
         repository (str):
             External repository to remove.
-        namespace (str):
-            Internal Quay namespace in which repository resides..
+        quay_org (str):
+            Quay organization in which repository resides.
         quay_api_token (str):
             OAuth token for authentication of Quay REST API.
         quay_user (str):
@@ -201,10 +201,10 @@ def remove_repository(
     sig_remover = SignatureRemover(quay_user=quay_user, quay_password=quay_password)
     sig_remover.set_quay_api_client(quay_api_client)
     sig_remover.remove_repository_signatures(
-        repository, namespace, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
+        repository, quay_org, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
     )
 
-    internal_repo = "{0}/{1}".format(namespace, get_internal_container_repo_name(repository))
+    internal_repo = "{0}/{1}".format(quay_org, get_internal_container_repo_name(repository))
     quay_api_client.delete_repository(internal_repo)
 
     LOG.info("Repository has been removed")

--- a/setup.py
+++ b/setup.py
@@ -127,6 +127,7 @@ setup(
             "pubtools._quay.merge_manifest_list:merge_manifest_list_main",
             "pubtools-quay-untag = pubtools._quay.untag_images:untag_images_main",
             "pubtools-quay-remove-repo = pubtools._quay.remove_repo:remove_repository_main",
+            "pubtools-quay-clear-repo = pubtools._quay.clear_repo:clear_repository_main",
         ],
         "target": [
             "push-docker = pubtools._quay.push_docker:mod_entry_point",

--- a/tests/test_clear_repo.py
+++ b/tests/test_clear_repo.py
@@ -10,8 +10,8 @@ def test_arg_constructor_required_args(mock_clear_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -27,7 +27,7 @@ def test_arg_constructor_required_args(mock_clear_repository):
     _, called_args = mock_clear_repository.call_args
 
     assert called_args["repository"] == "namespace/image"
-    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_org"] == "quay-organization"
     assert called_args["quay_user"] == "some-user"
     assert called_args["quay_password"] == "some-password"
     assert called_args["quay_api_token"] == "some-token"
@@ -43,8 +43,8 @@ def test_arg_constructor_all_args(mock_clear_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--pyxis-server",
@@ -69,7 +69,7 @@ def test_arg_constructor_all_args(mock_clear_repository):
     _, called_args = mock_clear_repository.call_args
 
     assert called_args["repository"] == "namespace/image"
-    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_org"] == "quay-organization"
     assert called_args["quay_user"] == "some-user"
     assert called_args["quay_password"] == "some-password"
     assert called_args["pyxis_server"] == "pyxis-url.com"
@@ -87,8 +87,8 @@ def test_arg_constructor_all_args(mock_clear_repository):
 def test_args_missing_repository(mock_clear_repository):
     wrong_args = [
         "dummy",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -115,8 +115,8 @@ def test_args_missing_api_token(mock_clear_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -139,8 +139,8 @@ def test_args_missing_quay_password(mock_clear_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-api-token",
@@ -164,8 +164,8 @@ def test_args_incorrect_repo(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace---image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -198,8 +198,8 @@ def test_args_missing_umb_url(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -229,8 +229,8 @@ def test_args_missing_umb_cert(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -264,8 +264,8 @@ def test_run(
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -295,13 +295,13 @@ def test_run(
     )
     mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
     mock_remove_repository_signatures.assert_called_once_with(
-        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+        "namespace/image", "quay-organization", "pyxis-url.com", "some-principal", None
     )
-    mock_get_repo_data.assert_called_once_with("internal-namespace/namespace----image")
+    mock_get_repo_data.assert_called_once_with("quay-organization/namespace----image")
     mock_untag_images.assert_called_once_with(
         [
-            "quay.io/internal-namespace/namespace----image:1",
-            "quay.io/internal-namespace/namespace----image:2",
+            "quay.io/quay-organization/namespace----image:1",
+            "quay.io/quay-organization/namespace----image:2",
         ],
         "some-token",
         remove_last=True,
@@ -327,8 +327,8 @@ def test_send_umb_message(
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -364,13 +364,13 @@ def test_send_umb_message(
 
     mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
     mock_remove_repository_signatures.assert_called_once_with(
-        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+        "namespace/image", "quay-organization", "pyxis-url.com", "some-principal", None
     )
-    mock_get_repo_data.assert_called_once_with("internal-namespace/namespace----image")
+    mock_get_repo_data.assert_called_once_with("quay-organization/namespace----image")
     mock_untag_images.assert_called_once_with(
         [
-            "quay.io/internal-namespace/namespace----image:1",
-            "quay.io/internal-namespace/namespace----image:2",
+            "quay.io/quay-organization/namespace----image:1",
+            "quay.io/quay-organization/namespace----image:2",
         ],
         "some-token",
         remove_last=True,

--- a/tests/test_clear_repo.py
+++ b/tests/test_clear_repo.py
@@ -1,0 +1,392 @@
+import mock
+import pytest
+
+from pubtools._quay import clear_repo
+
+
+@mock.patch("pubtools._quay.clear_repo.clear_repository")
+def test_arg_constructor_required_args(mock_clear_repository):
+    required_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+    clear_repo.clear_repository_main(required_args)
+    _, called_args = mock_clear_repository.call_args
+
+    assert called_args["repository"] == "namespace/image"
+    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_user"] == "some-user"
+    assert called_args["quay_password"] == "some-password"
+    assert called_args["quay_api_token"] == "some-token"
+    assert called_args["pyxis_server"] == "pyxis-url.com"
+    assert called_args["pyxis_krb_principal"] == "some-principal"
+    assert called_args["umb_topic"] == "VirtualTopic.eng.pub.quay_clear_repository"
+
+
+@mock.patch.dict("os.environ", {"QUAY_API_TOKEN": "api_token", "QUAY_PASSWORD": "some-password"})
+@mock.patch("pubtools._quay.clear_repo.clear_repository")
+def test_arg_constructor_all_args(mock_clear_repository):
+    all_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+        "--send-umb-msg",
+        "--umb-url",
+        "amqps://url:5671",
+        "--umb-url",
+        "amqps://url:5672",
+        "--umb-cert",
+        "/path/to/file.crt",
+        "--umb-client-key",
+        "/path/to/umb.key",
+        "--umb-ca-cert",
+        "/path/to/ca_cert.crt",
+        "--umb-topic",
+        "VirtualTopic.eng.pub.clear_repo_new",
+    ]
+    clear_repo.clear_repository_main(all_args)
+    _, called_args = mock_clear_repository.call_args
+
+    assert called_args["repository"] == "namespace/image"
+    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_user"] == "some-user"
+    assert called_args["quay_password"] == "some-password"
+    assert called_args["pyxis_server"] == "pyxis-url.com"
+    assert called_args["pyxis_krb_principal"] == "some-principal"
+    assert called_args["send_umb_msg"] is True
+    assert called_args["umb_urls"] == ["amqps://url:5671", "amqps://url:5672"]
+    assert called_args["umb_cert"] == "/path/to/file.crt"
+    assert called_args["umb_client_key"] == "/path/to/umb.key"
+    assert called_args["umb_ca_cert"] == "/path/to/ca_cert.crt"
+    assert called_args["quay_api_token"] == "api_token"
+    assert called_args["umb_topic"] == "VirtualTopic.eng.pub.clear_repo_new"
+
+
+@mock.patch("pubtools._quay.clear_repo.clear_repository")
+def test_args_missing_repository(mock_clear_repository):
+    wrong_args = [
+        "dummy",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+
+    with pytest.raises(SystemExit) as system_error:
+        clear_repo.clear_repository_main(wrong_args)
+
+    assert system_error.type == SystemExit
+    assert system_error.value.code == 2
+    mock_clear_repository.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.clear_repository")
+def test_args_missing_api_token(mock_clear_repository):
+    wrong_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+
+    with pytest.raises(ValueError, match="--quay-api-token must be specified"):
+        clear_repo.clear_repository_main(wrong_args)
+
+    mock_clear_repository.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.clear_repository")
+def test_args_missing_quay_password(mock_clear_repository):
+    wrong_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+
+    with pytest.raises(ValueError, match="--quay-password must be specified"):
+        clear_repo.clear_repository_main(wrong_args)
+
+    mock_clear_repository.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.QuayApiClient")
+def test_args_incorrect_repo(mock_quay_api_client, mock_send_umb_message):
+    wrong_args = [
+        "dummy",
+        "--repository",
+        "namespace---image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+
+    with pytest.raises(ValueError, match="Provided repository must have format <namespace>/<repo>"):
+        clear_repo.clear_repository_main(wrong_args)
+    wrong_args[2] == "/namespaceimage"
+    with pytest.raises(ValueError, match="Provided repository must have format <namespace>/<repo>"):
+        clear_repo.clear_repository_main(wrong_args)
+    wrong_args[2] == "namespaceimage/"
+    with pytest.raises(ValueError, match="Provided repository must have format <namespace>/<repo>"):
+        clear_repo.clear_repository_main(wrong_args)
+
+    mock_quay_api_client.assert_not_called()
+    mock_send_umb_message.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.QuayApiClient")
+def test_args_missing_umb_url(mock_quay_api_client, mock_send_umb_message):
+    wrong_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+        "--send-umb-msg",
+        "--umb-cert",
+        "/path/to/file.crt",
+    ]
+
+    with pytest.raises(ValueError, match="UMB URL must be specified.*"):
+        clear_repo.clear_repository_main(wrong_args)
+
+    mock_quay_api_client.assert_not_called()
+    mock_send_umb_message.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.QuayApiClient")
+def test_args_missing_umb_cert(mock_quay_api_client, mock_send_umb_message):
+    wrong_args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+        "--send-umb-msg",
+        "--umb-url",
+        "amqps://url:5671",
+    ]
+
+    with pytest.raises(ValueError, match="A path to a client certificate.*"):
+        clear_repo.clear_repository_main(wrong_args)
+
+    mock_quay_api_client.assert_not_called()
+    mock_send_umb_message.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.untag_images")
+@mock.patch("pubtools._quay.clear_repo.SignatureRemover")
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.QuayApiClient")
+def test_run(
+    mock_quay_api_client, mock_send_umb_message, mock_signature_remover, mock_untag_images
+):
+    args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+    ]
+    mock_get_repo_data = mock.MagicMock()
+    mock_get_repo_data.return_value = {"tags": {"1": {"some": " data"}, "2": {"some": "data"}}}
+    mock_quay_api_client.return_value.get_repository_data = mock_get_repo_data
+    mock_set_quay_api_client = mock.MagicMock()
+    mock_remove_repository_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.set_quay_api_client = mock_set_quay_api_client
+    mock_signature_remover.return_value.remove_repository_signatures = (
+        mock_remove_repository_signatures
+    )
+
+    clear_repo.clear_repository_main(args)
+
+    mock_quay_api_client.assert_called_once_with("some-token")
+    mock_signature_remover.assert_called_once_with(
+        quay_user="some-user", quay_password="some-password"
+    )
+    mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
+    mock_remove_repository_signatures.assert_called_once_with(
+        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+    )
+    mock_get_repo_data.assert_called_once_with("internal-namespace/namespace----image")
+    mock_untag_images.assert_called_once_with(
+        [
+            "quay.io/internal-namespace/namespace----image:1",
+            "quay.io/internal-namespace/namespace----image:2",
+        ],
+        "some-token",
+        remove_last=True,
+        quay_user="some-user",
+        quay_password="some-password",
+        send_umb_msg=False,
+        umb_urls=None,
+        umb_cert=None,
+        umb_client_key=None,
+        umb_ca_cert=None,
+    )
+    mock_send_umb_message.assert_not_called()
+
+
+@mock.patch("pubtools._quay.clear_repo.untag_images")
+@mock.patch("pubtools._quay.clear_repo.SignatureRemover")
+@mock.patch("pubtools._quay.clear_repo.send_umb_message")
+@mock.patch("pubtools._quay.clear_repo.QuayApiClient")
+def test_send_umb_message(
+    mock_quay_api_client, mock_send_umb_message, mock_signature_remover, mock_untag_images
+):
+    args = [
+        "dummy",
+        "--repository",
+        "namespace/image",
+        "--namespace",
+        "internal-namespace",
+        "--quay-user",
+        "some-user",
+        "--quay-password",
+        "some-password",
+        "--quay-api-token",
+        "some-token",
+        "--pyxis-server",
+        "pyxis-url.com",
+        "--pyxis-krb-principal",
+        "some-principal",
+        "--send-umb-msg",
+        "--umb-url",
+        "amqps://url:5671",
+        "--umb-cert",
+        "/path/to/file.crt",
+        "--umb-client-key",
+        "/path/to/umb.key",
+        "--umb-ca-cert",
+        "/path/to/ca_cert.crt",
+        "--umb-topic",
+        "VirtualTopic.eng.pub.clear_repo_new",
+    ]
+    mock_get_repo_data = mock.MagicMock()
+    mock_get_repo_data.return_value = {"tags": {"1": {"some": " data"}, "2": {"some": "data"}}}
+    mock_quay_api_client.return_value.get_repository_data = mock_get_repo_data
+    mock_set_quay_api_client = mock.MagicMock()
+    mock_remove_repository_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.set_quay_api_client = mock_set_quay_api_client
+    mock_signature_remover.return_value.remove_repository_signatures = (
+        mock_remove_repository_signatures
+    )
+    clear_repo.clear_repository_main(args)
+
+    mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
+    mock_remove_repository_signatures.assert_called_once_with(
+        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+    )
+    mock_get_repo_data.assert_called_once_with("internal-namespace/namespace----image")
+    mock_untag_images.assert_called_once_with(
+        [
+            "quay.io/internal-namespace/namespace----image:1",
+            "quay.io/internal-namespace/namespace----image:2",
+        ],
+        "some-token",
+        remove_last=True,
+        quay_user="some-user",
+        quay_password="some-password",
+        send_umb_msg=True,
+        umb_urls=["amqps://url:5671"],
+        umb_cert="/path/to/file.crt",
+        umb_client_key="/path/to/umb.key",
+        umb_ca_cert="/path/to/ca_cert.crt",
+    )
+    mock_send_umb_message.assert_called_once_with(
+        ["amqps://url:5671"],
+        {"cleared_repository": "namespace/image"},
+        "/path/to/file.crt",
+        "VirtualTopic.eng.pub.clear_repo_new",
+        client_key="/path/to/umb.key",
+        ca_cert="/path/to/ca_cert.crt",
+    )

--- a/tests/test_remove_repo.py
+++ b/tests/test_remove_repo.py
@@ -10,8 +10,8 @@ def test_arg_constructor_required_args(mock_remove_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -27,7 +27,7 @@ def test_arg_constructor_required_args(mock_remove_repository):
     _, called_args = mock_remove_repository.call_args
 
     assert called_args["repository"] == "namespace/image"
-    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_org"] == "quay-organization"
     assert called_args["quay_user"] == "some-user"
     assert called_args["quay_password"] == "some-password"
     assert called_args["quay_api_token"] == "some-token"
@@ -43,8 +43,8 @@ def test_arg_constructor_all_args(mock_remove_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--pyxis-server",
@@ -69,7 +69,7 @@ def test_arg_constructor_all_args(mock_remove_repository):
     _, called_args = mock_remove_repository.call_args
 
     assert called_args["repository"] == "namespace/image"
-    assert called_args["namespace"] == "internal-namespace"
+    assert called_args["quay_org"] == "quay-organization"
     assert called_args["quay_user"] == "some-user"
     assert called_args["quay_password"] == "some-password"
     assert called_args["pyxis_server"] == "pyxis-url.com"
@@ -87,8 +87,8 @@ def test_arg_constructor_all_args(mock_remove_repository):
 def test_args_missing_repository(mock_remove_repository):
     wrong_args = [
         "dummy",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -115,8 +115,8 @@ def test_args_missing_api_token(mock_remove_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -139,8 +139,8 @@ def test_args_missing_quay_password(mock_remove_repository):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-api-token",
@@ -164,8 +164,8 @@ def test_args_incorrect_repo(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace---image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -198,8 +198,8 @@ def test_args_missing_umb_url(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -229,8 +229,8 @@ def test_args_missing_umb_cert(mock_quay_api_client, mock_send_umb_message):
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -261,8 +261,8 @@ def test_run(mock_quay_api_client, mock_send_umb_message, mock_signature_remover
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -291,9 +291,9 @@ def test_run(mock_quay_api_client, mock_send_umb_message, mock_signature_remover
     )
     mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
     mock_remove_repository_signatures.assert_called_once_with(
-        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+        "namespace/image", "quay-organization", "pyxis-url.com", "some-principal", None
     )
-    mock_delete_repo.assert_called_once_with("internal-namespace/namespace----image")
+    mock_delete_repo.assert_called_once_with("quay-organization/namespace----image")
     mock_send_umb_message.assert_not_called()
 
 
@@ -305,8 +305,8 @@ def test_send_umb_message(mock_quay_api_client, mock_send_umb_message, mock_sign
         "dummy",
         "--repository",
         "namespace/image",
-        "--namespace",
-        "internal-namespace",
+        "--quay-org",
+        "quay-organization",
         "--quay-user",
         "some-user",
         "--quay-password",
@@ -341,9 +341,9 @@ def test_send_umb_message(mock_quay_api_client, mock_send_umb_message, mock_sign
 
     mock_set_quay_api_client.assert_called_once_with(mock_quay_api_client.return_value)
     mock_remove_repository_signatures.assert_called_once_with(
-        "namespace/image", "internal-namespace", "pyxis-url.com", "some-principal", None
+        "namespace/image", "quay-organization", "pyxis-url.com", "some-principal", None
     )
-    mock_delete_repo.assert_called_once_with("internal-namespace/namespace----image")
+    mock_delete_repo.assert_called_once_with("quay-organization/namespace----image")
     mock_send_umb_message.assert_called_once_with(
         ["amqps://url:5671"],
         {"removed_repository": "namespace/image"},


### PR DESCRIPTION
The code for removing the signatures of untagged images is taken
from repo removjng entrypoint, as the same principle applies.