### PR TITLE
Add signature removal to tag-docker operations

### DIFF
--- a/pubtools/_quay/signature_remover.py
+++ b/pubtools/_quay/signature_remover.py
@@ -294,8 +294,11 @@ class SignatureRemover:
         external_repo = get_external_container_repo_name(full_repo.split("/")[-1])
         image_digests = []
         repo_data = self.quay_api_client.get_repository_data(full_repo.split("/", 1)[-1])
+        # if specified tag doesn't exist in a repo, no-op
+        if tag not in repo_data["tags"]:
+            return
         # if image_id of the tag is specified, the image is V2S2 AKA source image
-        if repo_data["tags"][tag]["image_id"]:
+        elif repo_data["tags"][tag]["image_id"]:
             image_digests.append(repo_data["tags"][tag]["manifest_digest"])
 
         # if multiarch, we need digests of all archs

--- a/pubtools/_quay/signature_remover.py
+++ b/pubtools/_quay/signature_remover.py
@@ -249,3 +249,80 @@ class SignatureRemover:
             )
         else:
             LOG.info("No signatures need to be removed")
+
+    def remove_tag_signatures(
+        self,
+        reference,
+        pyxis_server,
+        pyxis_krb_principal,
+        pyxis_krb_ktfile=None,
+        exclude_by_claims=None,
+        remove_archs=None,
+    ):
+        """
+        Remove signatures of an image specified by a tag.
+
+        Source and multiarch images are supported. Signatures may be excluded from removal by
+        specifying a list of claim messages. If existing signature and a claim messages matches,
+        it is not removed, as the same exact signature would be recreated afterwards. Additionally,
+        it's also possible to only specify certain architectures whose signatures will be removed.
+        This option only has an effect when the image is a manifest list.
+
+        Args:
+            reference (str):
+                Image reference whose signatures are to be removed.
+            pyxis_server (str):
+                URL of the Pyxis service.
+            pyxis_krb_principal (str):
+                Kerberos principal to use for Pyxis authentication.
+            pyxis_krb_ktfile (str|None):
+                Path to Kerberos keytab file. Optional
+            exclude_by_claims ([dict]|None):
+                List of claim messages whose existing signature matches will not be removed.
+            remove_archs ([str]|None):
+                If specified and the reference is a multiarch image, only signatures of given
+                architectures will be eligible for removal.
+        """
+        if "@" in reference:
+            raise ValueError("Image, whose signatures are being removed must be specified by tag.")
+
+        full_repo, tag = reference.split(":", 1)
+        image_digests = []
+        repo_data = self.quay_api_client.get_repository_data(full_repo.split("/", 1)[-1])
+        # if image_id of the tag is specified, the image is V2S2 AKA source image
+        if repo_data["tags"][tag]["image_id"]:
+            image_digests.append(repo_data["tags"][tag]["manifest_digest"])
+
+        # if multiarch, we need digests of all archs
+        else:
+            manifest_list = self.quay_client.get_manifest(reference, manifest_list=True)
+            for manifest in manifest_list["manifests"]:
+                if remove_archs is None or manifest["platform"]["architecture"] in remove_archs:
+                    image_digests.append(manifest["digest"])
+
+        new_claims_signatures = (
+            list(set([(c["manifest_digest"], c["docker_reference"]) for c in exclude_by_claims]))
+            if isinstance(exclude_by_claims, list)
+            else []
+        )
+
+        remove_signature_ids = []
+        for sig in self.get_signatures_from_pyxis(
+            image_digests, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
+        ):
+            # if signature corresponds to to-be-removed digest+reference and isn't among new sigs
+            if (
+                sig["manifest_digest"] in image_digests
+                and sig["reference"] == reference
+                and (sig["manifest_digest"], sig["reference"]) not in new_claims_signatures
+            ):
+                remove_signature_ids.append(sig["_id"])
+
+        if len(remove_signature_ids) > 0:
+            LOG.info("{0} signatures will be removed".format(len(remove_signature_ids)))
+
+            self.remove_signatures_from_pyxis(
+                remove_signature_ids, pyxis_server, pyxis_krb_principal, pyxis_krb_ktfile
+            )
+        else:
+            LOG.info("No signatures need to be removed")

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -541,9 +541,7 @@ class TagDocker:
             exclude_by_claims=claim_messages,
         )
 
-        filtered_claim_messages = signature_handler.filter_claim_messages(claim_messages)
-
-        signature_handler.sign_claim_messages(filtered_claim_messages, True, True)
+        signature_handler.sign_claim_messages(claim_messages, True, True)
         ContainerImagePusher.run_tag_images(source_image, [dest_image], True, self.target_settings)
 
     def merge_manifest_lists_sign_images(self, push_item, tag, add_archs, signature_handler):
@@ -611,8 +609,7 @@ class TagDocker:
             exclude_by_claims=claim_messages,
         )
 
-        filtered_claim_messages = signature_handler.filter_claim_messages(claim_messages)
-        signature_handler.sign_claim_messages(filtered_claim_messages, True, True)
+        signature_handler.sign_claim_messages(claim_messages, True, True)
 
         raw_src_manifest = self.quay_client.get_manifest(source_image, manifest_list=True, raw=True)
 

--- a/tests/test_signature_remover.py
+++ b/tests/test_signature_remover.py
@@ -335,6 +335,43 @@ def test_remove_tag_signatures_multiarch(
 @mock.patch("pubtools._quay.signature_remover.SignatureRemover.get_signatures_from_pyxis")
 @mock.patch("pubtools._quay.signature_remover.QuayClient")
 @mock.patch("pubtools._quay.signature_remover.QuayApiClient")
+def test_remove_tag_signatures_non_existent_tag(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_get_signatures,
+    mock_remove_signatures,
+    repo_api_data,
+    manifest_list_data,
+):
+    mock_get_repository_data = mock.MagicMock()
+    mock_get_repository_data.return_value = repo_api_data
+    mock_quay_api_client.return_value.get_repository_data = mock_get_repository_data
+    mock_get_manifest = mock.MagicMock()
+    mock_get_manifest.return_value = manifest_list_data
+    mock_quay_client.return_value.get_manifest = mock_get_manifest
+
+    sig_remover = signature_remover.SignatureRemover(
+        quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
+    )
+    sig_remover.remove_tag_signatures(
+        "quay.io/internal-namespace/external-repo----external-image:5",
+        "pyxis-server.com",
+        "some-principal",
+        "some-keytab",
+    )
+
+    mock_get_repository_data.assert_called_once_with(
+        "internal-namespace/external-repo----external-image"
+    )
+    mock_get_manifest.assert_not_called()
+    mock_get_signatures.assert_not_called()
+    mock_remove_signatures.assert_not_called()
+
+
+@mock.patch("pubtools._quay.signature_remover.SignatureRemover.remove_signatures_from_pyxis")
+@mock.patch("pubtools._quay.signature_remover.SignatureRemover.get_signatures_from_pyxis")
+@mock.patch("pubtools._quay.signature_remover.QuayClient")
+@mock.patch("pubtools._quay.signature_remover.QuayApiClient")
 def test_remove_tag_signatures_source(
     mock_quay_api_client,
     mock_quay_client,

--- a/tests/test_signature_remover.py
+++ b/tests/test_signature_remover.py
@@ -273,18 +273,27 @@ def test_remove_tag_signatures_multiarch(
 
     mock_get_signatures.return_value = [
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id1",
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id2",
             "manifest_digest": "sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
         },
         {
-            "reference": "quay.io/some-namespace/other-repo:1",
+            "repository": "external-repo/other-image",
+            "reference": "redhat.com/external-repo/other-image:1",
             "_id": "id3",
+            "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
+        },
+        {
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:2",
+            "_id": "id4",
             "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
         },
     ]
@@ -293,12 +302,17 @@ def test_remove_tag_signatures_multiarch(
         quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
     )
     sig_remover.remove_tag_signatures(
-        "quay.io/some-namespace/some-repo:1", "pyxis-server.com", "some-principal", "some-keytab"
+        "quay.io/internal-namespace/external-repo----external-image:1",
+        "pyxis-server.com",
+        "some-principal",
+        "some-keytab",
     )
 
-    mock_get_repository_data.assert_called_once_with("some-namespace/some-repo")
+    mock_get_repository_data.assert_called_once_with(
+        "internal-namespace/external-repo----external-image"
+    )
     mock_get_manifest.assert_called_once_with(
-        "quay.io/some-namespace/some-repo:1", manifest_list=True
+        "quay.io/internal-namespace/external-repo----external-image:1", manifest_list=True
     )
     mock_get_signatures.assert_called_once_with(
         [
@@ -338,19 +352,28 @@ def test_remove_tag_signatures_source(
 
     mock_get_signatures.return_value = [
         {
-            "reference": "quay.io/some-namespace/some-repo:3",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:3",
             "_id": "id1",
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
         {
-            "reference": "quay.io/some-namespace/some-repo:3",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:3",
             "_id": "id2",
             "manifest_digest": "sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
         },
         {
-            "reference": "quay.io/some-namespace/other-repo:3",
+            "repository": "external-repo/other-image",
+            "reference": "redhat.com/external-repo/other-image:3",
             "_id": "id3",
-            "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
+            "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
+        },
+        {
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:4",
+            "_id": "id4",
+            "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
     ]
 
@@ -358,10 +381,15 @@ def test_remove_tag_signatures_source(
         quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
     )
     sig_remover.remove_tag_signatures(
-        "quay.io/some-namespace/some-repo:3", "pyxis-server.com", "some-principal", "some-keytab"
+        "quay.io/internal-namespace/external-repo----external-image:3",
+        "pyxis-server.com",
+        "some-principal",
+        "some-keytab",
     )
 
-    mock_get_repository_data.assert_called_once_with("some-namespace/some-repo")
+    mock_get_repository_data.assert_called_once_with(
+        "internal-namespace/external-repo----external-image"
+    )
     mock_get_manifest.assert_not_called()
     mock_get_signatures.assert_called_once_with(
         ["sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb"],
@@ -422,17 +450,20 @@ def test_remove_tag_signatures_no_signatures(
 
     mock_get_signatures.return_value = [
         {
-            "reference": "quay.io/some-namespace/some-repo:2",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:2",
             "_id": "id1",
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
         {
-            "reference": "quay.io/some-namespace/some-repo:3",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:3",
             "_id": "id2",
             "manifest_digest": "sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
         },
         {
-            "reference": "quay.io/some-namespace/other-repo:1",
+            "repository": "external-repo/other-image",
+            "reference": "redhat.com/external-repo/other-image:1",
             "_id": "id3",
             "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
         },
@@ -442,7 +473,10 @@ def test_remove_tag_signatures_no_signatures(
         quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
     )
     sig_remover.remove_tag_signatures(
-        "quay.io/some-namespace/some-repo:1", "pyxis-server.com", "some-principal", "some-keytab"
+        "quay.io/internal-namespace/external-repo----external-image:1",
+        "pyxis-server.com",
+        "some-principal",
+        "some-keytab",
     )
 
     mock_remove_signatures.assert_not_called()
@@ -469,17 +503,20 @@ def test_remove_tag_signatures_exclude_by_claims(
 
     mock_get_signatures.return_value = [
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id1",
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id2",
             "manifest_digest": "sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
         },
         {
-            "reference": "quay.io/some-namespace/other-repo:1",
+            "repository": "external-repo/other-image",
+            "reference": "redhat.com/external-repo/other-image:1",
             "_id": "id3",
             "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
         },
@@ -488,11 +525,11 @@ def test_remove_tag_signatures_exclude_by_claims(
     claim_messages = [
         {
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
-            "docker_reference": "quay.io/some-namespace/some-repo:1",
+            "docker_reference": "redhat.com/external-repo/external-image:1",
         },
         {
             "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
-            "docker_reference": "quay.io/some-namespace/some-repo:1",
+            "docker_reference": "redhat.com/external-repo/external-image:1",
         },
     ]
 
@@ -500,16 +537,18 @@ def test_remove_tag_signatures_exclude_by_claims(
         quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
     )
     sig_remover.remove_tag_signatures(
-        "quay.io/some-namespace/some-repo:1",
+        "quay.io/internal-namespace/external-repo----external-image:1",
         "pyxis-server.com",
         "some-principal",
         "some-keytab",
         exclude_by_claims=claim_messages,
     )
 
-    mock_get_repository_data.assert_called_once_with("some-namespace/some-repo")
+    mock_get_repository_data.assert_called_once_with(
+        "internal-namespace/external-repo----external-image"
+    )
     mock_get_manifest.assert_called_once_with(
-        "quay.io/some-namespace/some-repo:1", manifest_list=True
+        "quay.io/internal-namespace/external-repo----external-image:1", manifest_list=True
     )
     mock_get_signatures.assert_called_once_with(
         [
@@ -549,17 +588,20 @@ def test_remove_tag_signatures_selected_archs(
 
     mock_get_signatures.return_value = [
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id1",
             "manifest_digest": "sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
         },
         {
-            "reference": "quay.io/some-namespace/some-repo:1",
+            "repository": "external-repo/external-image",
+            "reference": "redhat.com/external-repo/external-image:1",
             "_id": "id2",
             "manifest_digest": "sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
         },
         {
-            "reference": "quay.io/some-namespace/other-repo:1",
+            "repository": "external-repo/other-image",
+            "reference": "redhat.com/external-repo/other-image:1",
             "_id": "id3",
             "manifest_digest": "sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
         },
@@ -571,16 +613,18 @@ def test_remove_tag_signatures_selected_archs(
         quay_user="some-user", quay_password="some-password", quay_api_token="some-token"
     )
     sig_remover.remove_tag_signatures(
-        "quay.io/some-namespace/some-repo:1",
+        "quay.io/internal-namespace/external-repo----external-image:1",
         "pyxis-server.com",
         "some-principal",
         "some-keytab",
         remove_archs=selected_archs,
     )
 
-    mock_get_repository_data.assert_called_once_with("some-namespace/some-repo")
+    mock_get_repository_data.assert_called_once_with(
+        "internal-namespace/external-repo----external-image"
+    )
     mock_get_manifest.assert_called_once_with(
-        "quay.io/some-namespace/some-repo:1", manifest_list=True
+        "quay.io/internal-namespace/external-repo----external-image:1", manifest_list=True
     )
     mock_get_signatures.assert_called_once_with(
         [

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -1608,9 +1608,6 @@ def test_copy_all_archs_sign_images_source(
     sig_handler = mock.MagicMock()
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
-    mock_filter_claim_messages = mock.MagicMock()
-    mock_filter_claim_messages.side_effect = lambda claims: claims
-    sig_handler.filter_claim_messages = mock_filter_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
     # shorten the ML to have less claim messages
     source_details = tag_docker.TagDocker.ImageDetails(
@@ -1660,7 +1657,6 @@ def test_copy_all_archs_sign_images_source(
         True,
         target_settings,
     )
-    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1"])
     mock_remove_tag_signatures.assert_called_once_with(
         reference="quay.io/some-namespace/namespace----test_repo:v1.6",
         pyxis_server="pyxis-url.com",
@@ -1739,9 +1735,6 @@ def test_merge_manifest_lists_sign_images(
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
-    mock_filter_claim_messages = mock.MagicMock()
-    mock_filter_claim_messages.side_effect = lambda claims: claims
-    sig_handler.filter_claim_messages = mock_filter_claim_messages
     mock_remove_tag_signatures = mock.MagicMock()
     mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
 
@@ -1818,7 +1811,6 @@ def test_merge_manifest_lists_sign_images(
         new_manifest_list, "quay.io/some-namespace/namespace----test_repo:v1.6"
     )
 
-    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1", "msg2", "msg3"])
     mock_remove_tag_signatures.assert_called_once_with(
         reference="quay.io/some-namespace/namespace----test_repo:v1.6",
         pyxis_server="pyxis-url.com",
@@ -1854,9 +1846,6 @@ def test_merge_manifest_lists_sign_images_upload_original_manifest(
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
-    mock_filter_claim_messages = mock.MagicMock()
-    mock_filter_claim_messages.side_effect = lambda claims: claims
-    sig_handler.filter_claim_messages = mock_filter_claim_messages
     mock_remove_tag_signatures = mock.MagicMock()
     mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
 
@@ -1906,7 +1895,6 @@ def test_merge_manifest_lists_sign_images_upload_original_manifest(
         "quay.io/some-namespace/namespace----test_repo:v1.6",
         raw=True,
     )
-    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1", "msg2", "msg3"])
     mock_remove_tag_signatures.assert_called_once_with(
         reference="quay.io/some-namespace/namespace----test_repo:v1.6",
         pyxis_server="pyxis-url.com",
@@ -2485,9 +2473,6 @@ def test_copy_all_archs_sign_images_source_none_signing_key(
     push_item_none_key.claims_signing_key = None
     mock_remove_tag_signatures = mock.MagicMock()
     mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
-    mock_filter_claim_messages = mock.MagicMock()
-    mock_filter_claim_messages.side_effect = lambda claims: claims
-    sig_handler.filter_claim_messages = mock_filter_claim_messages
 
     tag_docker_instance = tag_docker.TagDocker(
         [push_item_none_key],
@@ -2506,7 +2491,6 @@ def test_copy_all_archs_sign_images_source_none_signing_key(
         True,
         target_settings,
     )
-    mock_filter_claim_messages.assert_called_once_with([])
     mock_remove_tag_signatures.assert_called_once_with(
         reference="quay.io/some-namespace/namespace----test_repo:v1.6",
         pyxis_server="pyxis-url.com",
@@ -2552,9 +2536,6 @@ def test_merge_manifest_lists_sign_images_none_signing_key(
     push_item_none_key.claims_signing_key = None
     mock_remove_tag_signatures = mock.MagicMock()
     mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
-    mock_filter_claim_messages = mock.MagicMock()
-    mock_filter_claim_messages.side_effect = lambda claims: claims
-    sig_handler.filter_claim_messages = mock_filter_claim_messages
 
     tag_docker_instance = tag_docker.TagDocker(
         [push_item_none_key],
@@ -2572,7 +2553,6 @@ def test_merge_manifest_lists_sign_images_none_signing_key(
     mock_upload_manifest.assert_called_once_with(
         new_manifest_list, "quay.io/some-namespace/namespace----test_repo:v1.6"
     )
-    mock_filter_claim_messages.assert_called_once_with([])
     mock_remove_tag_signatures.assert_called_once_with(
         reference="quay.io/some-namespace/namespace----test_repo:v1.6",
         pyxis_server="pyxis-url.com",

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -47,8 +47,6 @@ def test_init_verify_target_settings_ok(
     assert tag_docker_instance.target_settings == target_settings
     assert tag_docker_instance.quay_host == "quay.io"
     mock_remote_executor.assert_not_called()
-    mock_quay_client.assert_not_called()
-    mock_quay_api_client.assert_not_called()
 
     assert tag_docker_instance.quay_client == mock_quay_client.return_value
     assert tag_docker_instance.quay_api_client == mock_quay_api_client.return_value
@@ -72,10 +70,8 @@ def test_init_missing_target_setting(
     tag_docker_push_item_add,
 ):
     hub = mock.MagicMock()
-    target_settings.pop("dest_quay_user")
-    with pytest.raises(
-        exceptions.InvalidTargetSettings, match="'dest_quay_user' must be present.*"
-    ):
+    target_settings.pop("pyxis_server")
+    with pytest.raises(exceptions.InvalidTargetSettings, match="'pyxis_server' must be present.*"):
         tag_docker_instance = tag_docker.TagDocker(
             [tag_docker_push_item_add],
             hub,
@@ -1589,6 +1585,7 @@ def test_tag_add_calculate_archs_different_manifest_types(
     )
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.RemoteExecutor")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.QuayApiClient")
@@ -1602,6 +1599,7 @@ def test_copy_all_archs_sign_images_source(
     mock_quay_api_client,
     mock_quay_client,
     mock_remote_executor,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_add,
     v2s2_manifest_data,
@@ -1610,6 +1608,9 @@ def test_copy_all_archs_sign_images_source(
     sig_handler = mock.MagicMock()
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
+    mock_filter_claim_messages = mock.MagicMock()
+    mock_filter_claim_messages.side_effect = lambda claims: claims
+    sig_handler.filter_claim_messages = mock_filter_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
     # shorten the ML to have less claim messages
     source_details = tag_docker.TagDocker.ImageDetails(
@@ -1619,6 +1620,9 @@ def test_copy_all_archs_sign_images_source(
         "sha256:8a3a33cad0bd33650ba7287a7ec94327d8e47ddf7845c569c80b5c4b20d49d36",
     )
     mock_get_image_details.return_value = source_details
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
+
     tag_docker_instance = tag_docker.TagDocker(
         [tag_docker_push_item_add],
         hub,
@@ -1655,6 +1659,14 @@ def test_copy_all_archs_sign_images_source(
         ["quay.io/some-namespace/namespace----test_repo:v1.6"],
         True,
         target_settings,
+    )
+    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1"])
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo:v1.6",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        exclude_by_claims=["msg0", "msg1"],
     )
 
 
@@ -1701,6 +1713,7 @@ def test_tag_sign_images_multiarch_error(
     mock_run_tag_images.assert_not_called()
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.RemoteExecutor")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.QuayApiClient")
@@ -1716,6 +1729,7 @@ def test_merge_manifest_lists_sign_images(
     mock_quay_api_client,
     mock_quay_client,
     mock_remote_executor,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_add,
     manifest_list_data,
@@ -1725,6 +1739,11 @@ def test_merge_manifest_lists_sign_images(
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
+    mock_filter_claim_messages = mock.MagicMock()
+    mock_filter_claim_messages.side_effect = lambda claims: claims
+    sig_handler.filter_claim_messages = mock_filter_claim_messages
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
 
     # shorten the ML to have less claim messages
     new_manifest_list = deepcopy(manifest_list_data)
@@ -1799,7 +1818,17 @@ def test_merge_manifest_lists_sign_images(
         new_manifest_list, "quay.io/some-namespace/namespace----test_repo:v1.6"
     )
 
+    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1", "msg2", "msg3"])
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo:v1.6",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        exclude_by_claims=["msg0", "msg1", "msg2", "msg3"],
+    )
 
+
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.RemoteExecutor")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.QuayApiClient")
@@ -1815,6 +1844,7 @@ def test_merge_manifest_lists_sign_images_upload_original_manifest(
     mock_quay_api_client,
     mock_quay_client,
     mock_remote_executor,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_add,
     manifest_list_data,
@@ -1824,6 +1854,11 @@ def test_merge_manifest_lists_sign_images_upload_original_manifest(
     mock_sign_claim_messages = mock.MagicMock()
     sig_handler.sign_claim_messages = mock_sign_claim_messages
     mock_create_claim_message.side_effect = ["msg{0}".format(i) for i in range(50)]
+    mock_filter_claim_messages = mock.MagicMock()
+    mock_filter_claim_messages.side_effect = lambda claims: claims
+    sig_handler.filter_claim_messages = mock_filter_claim_messages
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
 
     # shorten the ML to have less claim messages
     new_manifest_list = deepcopy(manifest_list_data)
@@ -1871,6 +1906,14 @@ def test_merge_manifest_lists_sign_images_upload_original_manifest(
         "quay.io/some-namespace/namespace----test_repo:v1.6",
         raw=True,
     )
+    mock_filter_claim_messages.assert_called_once_with(["msg0", "msg1", "msg2", "msg3"])
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo:v1.6",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        exclude_by_claims=["msg0", "msg1", "msg2", "msg3"],
+    )
 
 
 @mock.patch("pubtools._quay.tag_docker.untag_images")
@@ -1913,6 +1956,7 @@ def test_run_untag_images_dont_remove_last(mock_untag_images, target_settings):
     )
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.RemoteExecutor")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.QuayApiClient")
@@ -1922,10 +1966,13 @@ def test_untag_image(
     mock_quay_api_client,
     mock_quay_client,
     mock_remote_executor,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_remove_src,
 ):
     hub = mock.MagicMock()
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
     tag_docker_instance = tag_docker.TagDocker(
         [tag_docker_push_item_remove_src],
         hub,
@@ -1938,8 +1985,15 @@ def test_untag_image(
     mock_run_untag_images.assert_called_once_with(
         ["quay.io/some-namespace/namespace----test_repo2:v1.8"], True, target_settings
     )
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo2:v1.8",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+    )
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.RemoteExecutor")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.QuayApiClient")
@@ -1947,6 +2001,7 @@ def test_manifest_list_remove_archs(
     mock_quay_api_client,
     mock_quay_client,
     mock_remote_executor,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_remove_src,
     manifest_list_data,
@@ -1957,6 +2012,8 @@ def test_manifest_list_remove_archs(
     mock_quay_client.return_value.get_manifest = mock_get_manifest
     mock_upload_manifest = mock.MagicMock()
     mock_quay_client.return_value.upload_manifest = mock_upload_manifest
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
     tag_docker_instance = tag_docker.TagDocker(
         [tag_docker_push_item_remove_src],
         hub,
@@ -1975,6 +2032,14 @@ def test_manifest_list_remove_archs(
     )
     mock_upload_manifest.assert_called_once_with(
         expected_manifest_list, "quay.io/some-namespace/namespace----test_repo2:v1.8"
+    )
+
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo2:v1.8",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        remove_archs=["amd64", "arm64", "arm"],
     )
 
 
@@ -2392,6 +2457,7 @@ def test_mod_entrypoint(
     mock_run.assert_called_once_with()
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.TagDocker.get_image_details")
 @mock.patch("pubtools._quay.tag_docker.SignatureHandler.create_manifest_claim_message")
 @mock.patch("pubtools._quay.tag_docker.ContainerImagePusher.run_tag_images")
@@ -2399,6 +2465,7 @@ def test_copy_all_archs_sign_images_source_none_signing_key(
     mock_run_tag_images,
     mock_create_claim_message,
     mock_get_image_details,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_add,
     v2s2_manifest_data,
@@ -2416,6 +2483,11 @@ def test_copy_all_archs_sign_images_source_none_signing_key(
     mock_get_image_details.return_value = source_details
     push_item_none_key = tag_docker_push_item_add
     push_item_none_key.claims_signing_key = None
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
+    mock_filter_claim_messages = mock.MagicMock()
+    mock_filter_claim_messages.side_effect = lambda claims: claims
+    sig_handler.filter_claim_messages = mock_filter_claim_messages
 
     tag_docker_instance = tag_docker.TagDocker(
         [push_item_none_key],
@@ -2434,8 +2506,17 @@ def test_copy_all_archs_sign_images_source_none_signing_key(
         True,
         target_settings,
     )
+    mock_filter_claim_messages.assert_called_once_with([])
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo:v1.6",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        exclude_by_claims=[],
+    )
 
 
+@mock.patch("pubtools._quay.tag_docker.SignatureRemover")
 @mock.patch("pubtools._quay.tag_docker.QuayClient")
 @mock.patch("pubtools._quay.tag_docker.SignatureHandler.create_manifest_claim_message")
 @mock.patch("pubtools._quay.tag_docker.ContainerImagePusher.run_tag_images")
@@ -2445,6 +2526,7 @@ def test_merge_manifest_lists_sign_images_none_signing_key(
     mock_run_tag_images,
     mock_create_claim_message,
     mock_quay_client,
+    mock_signature_remover,
     target_settings,
     tag_docker_push_item_add,
     manifest_list_data,
@@ -2468,6 +2550,11 @@ def test_merge_manifest_lists_sign_images_none_signing_key(
     mock_quay_client.return_value.get_manifest = mock_get_manifest
     push_item_none_key = tag_docker_push_item_add
     push_item_none_key.claims_signing_key = None
+    mock_remove_tag_signatures = mock.MagicMock()
+    mock_signature_remover.return_value.remove_tag_signatures = mock_remove_tag_signatures
+    mock_filter_claim_messages = mock.MagicMock()
+    mock_filter_claim_messages.side_effect = lambda claims: claims
+    sig_handler.filter_claim_messages = mock_filter_claim_messages
 
     tag_docker_instance = tag_docker.TagDocker(
         [push_item_none_key],
@@ -2484,4 +2571,12 @@ def test_merge_manifest_lists_sign_images_none_signing_key(
     mock_sign_claim_messages.assert_called_once_with([], True, True)
     mock_upload_manifest.assert_called_once_with(
         new_manifest_list, "quay.io/some-namespace/namespace----test_repo:v1.6"
+    )
+    mock_filter_claim_messages.assert_called_once_with([])
+    mock_remove_tag_signatures.assert_called_once_with(
+        reference="quay.io/some-namespace/namespace----test_repo:v1.6",
+        pyxis_server="pyxis-url.com",
+        pyxis_krb_principal="some-principal@REDHAT.COM",
+        pyxis_krb_ktfile="/etc/pub/some.keytab",
+        exclude_by_claims=[],
     )


### PR DESCRIPTION
A somewhat unrelated change is adding the filtering of claim messages
which already exist as signatures.