### PR TITLE
refactor: drop unnecessary 'external_repos'

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -146,21 +146,6 @@ class PushDocker:
 
         return docker_push_items
 
-    @log_step("Translate docker push items")
-    def filter_unrelated_repos(self, push_items):
-        """Remove item repos from tag mapping if external_repos is set for push item.
-
-        Args:
-            push_items ([ContainerPushItem]):
-                Container push items containing the repositories.
-        """
-        for push_item in push_items:
-            if push_item.external_repos:
-                #  if external repos is defined, push items was populated by ET
-                #  item.repos have to be removed from tags mapping
-                for repo in list(push_item.repos):
-                    push_item.metadata["tags"].pop(repo)
-
     @log_step("Get operator push items")
     def get_operator_push_items(self):
         """
@@ -527,8 +512,6 @@ class PushDocker:
         docker_push_items = self.get_docker_push_items()
         # Get operator push items (done early so that possible issues are detected)
         operator_push_items = self.get_operator_push_items()
-        # Remove item.repos from tag mapping if needed
-        self.filter_unrelated_repos(docker_push_items)
         # Check if we may push to destination repos
         self.check_repos_validity(
             docker_push_items, self.hub, self.target_settings, self.quay_api_client
@@ -584,10 +567,7 @@ class PushDocker:
         # Return repos for UD cache flush
         repos = []
         for item in docker_push_items:
-            if item.external_repos:
-                repos += item.external_repos.keys()
-            else:
-                repos += item.repos.keys()
+            repos += item.repos.keys()
 
         return sorted(list(set(repos)))
 

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -995,7 +995,7 @@ def test_push_docker_full_success_repush(
         {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
     )
     mock_rollback.assert_not_called()
-    assert repos == ["external/repo", "test_repo"]
+    assert repos == ["test_repo"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -1187,19 +1187,6 @@ def test_mod_entrypoint(
         target_settings,
     )
     mock_run.assert_called_once_with()
-
-
-@mock.patch("pubtools._quay.push_docker.PushDocker.verify_target_settings")
-def test_filter_unrelated_repos(patched_verify_target_settings, container_push_item_external_repos):
-    assert "test_repo" in container_push_item_external_repos.metadata["tags"]
-    push_docker.PushDocker(
-        [container_push_item_external_repos],
-        mock.MagicMock(),
-        mock.MagicMock(),
-        mock.MagicMock(),
-        mock.MagicMock(),
-    ).filter_unrelated_repos([container_push_item_external_repos])
-    assert "test_repo" not in container_push_item_external_repos.metadata["tags"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.verify_target_settings")


### PR DESCRIPTION
Pub refactor will make it so that the preferred repo format is always
used in 'repos' attribute. We no longer need to check two places for
repos or rewrite other attributes of our push items.