### PR TITLE
Skip signing when no operator claim messages constructed

### DIFF
--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -499,7 +499,7 @@ class ContainerSignatureHandler(SignatureHandler):
             claim_messages += self.construct_item_claim_messages(item)
         claim_messages = self.remove_duplicate_claim_messages(claim_messages)
         claim_messages = self.filter_claim_messages(claim_messages)
-        if len(claim_messages) == 0:
+        if not claim_messages:
             LOG.info("No new claim messages will be uploaded")
             return
 
@@ -598,6 +598,10 @@ class OperatorSignatureHandler(SignatureHandler):
                 intermediate_index_image, version, signing_keys
             )
 
+        if not claim_messages:
+            LOG.info("No new claim messages will be uploaded")
+            return
+
         signature_messages = self.get_signatures_from_radas(claim_messages)
         self.validate_radas_messages(claim_messages, signature_messages)
 
@@ -626,6 +630,10 @@ class OperatorSignatureHandler(SignatureHandler):
                 Tag of the result index image.
         """
         claim_messages = self.construct_index_image_claim_messages(index_image, tag, signing_keys)
+        if not claim_messages:
+            LOG.info("No new claim messages will be uploaded")
+            return
+
         signature_messages = self.get_signatures_from_radas(claim_messages)
         self.validate_radas_messages(claim_messages, signature_messages)
 
@@ -680,7 +688,7 @@ class BasicSignatureHandler(SignatureHandler):
             claim_messages = self.remove_duplicate_claim_messages(claim_messages)
         if filter_existing:
             claim_messages = self.filter_claim_messages(claim_messages)
-        if len(claim_messages) == 0:
+        if not claim_messages:
             LOG.info("No new claim messages will be uploaded")
             return
 


### PR DESCRIPTION
It's a follow-up fix of #25 which only avoids creating claim messages
for operator images when signing key is None, but not skip signing.