### PR TITLE
Add support for delimeter-less repositories

### DIFF
--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -16,7 +16,7 @@ LOG.setLevel(logging.INFO)
 
 CLEAR_REPO_ARGS = {
     ("--repositories",): {
-        "help": "External repositories to clear as CSV. Must be in format <namespace>/<repo>.",
+        "help": "External repositories to clear as CSV.",
         "required": True,
         "type": str,
     },

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -15,7 +15,7 @@ LOG.setLevel(logging.INFO)
 
 REMOVE_REPO_ARGS = {
     ("--repositories",): {
-        "help": "External repositories to remove as CSV. Must be in format <namespace>/<repo>.",
+        "help": "External repositories to remove as CSV.",
         "required": True,
         "type": str,
     },

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -200,14 +200,24 @@ def get_internal_container_repo_name(external_name):
     Expected input format: <namespace>/<product>
     Generated output format: <namespace>----<product>
 
+    NOTE: Repositories without a delimeter "/" may actually exist. In that case, the function
+    simply returns the repo without any alterations.
+
     Args:
         external_name (str):
             External repository name.
     Returns:
         Internal repository name.
     """
-    if external_name.count("/") != 1 or external_name[0] == "/" or external_name[-1] == "/":
-        raise ValueError("Input repository should have the format '<namespace>/<product>'")
+    if external_name.count("/") == 0:
+        return external_name
+
+    if external_name.count("/") > 1 or external_name[0] == "/" or external_name[-1] == "/":
+        raise ValueError(
+            "Input repository containing a delimeter should "
+            "have the format '<namespace>/<product>'",
+            external_name,
+        )
 
     return external_name.replace("/", INTERNAL_DELIMITER)
 
@@ -219,19 +229,27 @@ def get_external_container_repo_name(internal_name):
     Expected input format: <namespace>----<product>
     Generated output format: <namespace>/<product>
 
+    NOTE: Repositories without a delimeter "----" may actually exist. In that case, the function
+    simply returns the repo without any alterations.
+
     Args:
         internal_name (str):
             Internal repository name.
     Returns:
         External repository name.
     """
+    if internal_name.count(INTERNAL_DELIMITER) == 0:
+        return internal_name
+
     if (
-        internal_name.count(INTERNAL_DELIMITER) != 1
+        internal_name.count(INTERNAL_DELIMITER) > 1
         or internal_name.find(INTERNAL_DELIMITER) == 0
         or internal_name.find(INTERNAL_DELIMITER) == len(internal_name) - 4
     ):
         raise ValueError(
-            "Input repository should have the format '<namespace>----<product>'", internal_name
+            "Input repository containing a delimeter should "
+            "have the format '<namespace>----<product>'",
+            internal_name,
         )
 
     return internal_name.replace(INTERNAL_DELIMITER, "/")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,14 +58,19 @@ def test_get_internal_repo_name():
     assert internal_name == "namespace----repo"
 
 
+def test_get_internal_repo_name_no_delimeter():
+    internal_name = misc.get_internal_container_repo_name("namespace-repo")
+    assert internal_name == "namespace-repo"
+
+
 def test_get_internal_repo_name_errors():
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_internal_container_repo_name("/namespacerepo")
 
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_internal_container_repo_name("namespacerepo/")
 
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_internal_container_repo_name("name/space/repo")
 
 
@@ -74,12 +79,17 @@ def test_get_external_repo_name():
     assert internal_name == "namespace/repo"
 
 
+def test_get_external_repo_name_no_delimeter():
+    internal_name = misc.get_external_container_repo_name("namespace-repo")
+    assert internal_name == "namespace-repo"
+
+
 def test_get_external_repo_name_errors():
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_external_container_repo_name("----namespacerepo")
 
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_external_container_repo_name("namespacerepo----")
 
-    with pytest.raises(ValueError, match="Input repository should have the format.*"):
+    with pytest.raises(ValueError, match="Input repository containing a delimeter.*"):
         misc.get_external_container_repo_name("name----space----repo")


### PR DESCRIPTION
Normally, repository consists of namespace and repo parts,
separated by "/". However, repositories which don't contain this
separator exist as well, and have to be supported by pubtools-quay.
Delimeter transformation has been changed to be a no-op when this
type of repo is encountered.