### PR TITLE
Fix loggers per pubtools conventions

### DIFF
--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -10,9 +10,7 @@ from .utils.misc import (
     get_internal_container_repo_name,
 )
 
-LOG = logging.getLogger()
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 CLEAR_REPO_ARGS = {
     ("--repositories",): {
@@ -239,6 +237,8 @@ def clear_repositories(
 
 def clear_repositories_main(sysargs=None):
     """Entrypoint for clearing repositories."""
+    logging.basicConfig(level=logging.INFO)
+
     parser = setup_arg_parser(CLEAR_REPO_ARGS)
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -7,8 +7,7 @@ from six.moves import shlex_quote
 
 import paramiko
 
-LOG = logging.getLogger("PubLogger")
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 # Python 2.6 version of paramiko doesn't support the usage

--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -14,9 +14,7 @@ from .quay_client import QuayClient
 from .tag_images import tag_images
 from .manifest_list_merger import ManifestListMerger
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class ContainerImagePusher:

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -6,8 +6,7 @@ from .operator_pusher import OperatorPusher
 from .signature_handler import OperatorSignatureHandler
 from .utils.misc import get_internal_container_repo_name
 
-LOG = logging.getLogger("PubLogger")
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 def verify_target_settings(target_settings):

--- a/pubtools/_quay/image_untagger.py
+++ b/pubtools/_quay/image_untagger.py
@@ -3,9 +3,7 @@ import logging
 from .quay_client import QuayClient
 from .quay_api_client import QuayApiClient
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class ImageUntagger:

--- a/pubtools/_quay/manifest_claims_handler.py
+++ b/pubtools/_quay/manifest_claims_handler.py
@@ -8,7 +8,7 @@ import proton
 
 import monotonic
 
-LOG = logging.getLogger("PubLogger")
+LOG = logging.getLogger("pubtools.quay")
 
 # There are some linting errors since this was copied from rcm-pub
 # flake8: noqa: D101, D107, D102, D205, D400, D403

--- a/pubtools/_quay/manifest_list_merger.py
+++ b/pubtools/_quay/manifest_list_merger.py
@@ -5,9 +5,7 @@ import requests
 
 from .quay_client import QuayClient
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class ManifestListMerger:

--- a/pubtools/_quay/merge_manifest_list.py
+++ b/pubtools/_quay/merge_manifest_list.py
@@ -3,9 +3,7 @@ import logging
 from .utils.misc import setup_arg_parser, add_args_env_variables
 from .manifest_list_merger import ManifestListMerger
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 MERGE_MANIFEST_LIST_ARGS = {
     ("--source-ref",): {
@@ -58,6 +56,8 @@ def verify_merge_manifest_list_args(args):
 
 def merge_manifest_list_main(sysargs=None):
     """Entrypoint for manifest list merging."""
+    logging.basicConfig(level=logging.INFO)
+
     parser = setup_arg_parser(MERGE_MANIFEST_LIST_ARGS)
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -9,9 +9,7 @@ from requests.packages.urllib3.util.retry import Retry
 from .container_image_pusher import ContainerImagePusher
 from .utils.misc import run_entrypoint, get_internal_container_repo_name, log_step
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class OperatorPusher:

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -18,9 +18,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class PushDocker:

--- a/pubtools/_quay/quay_api_client.py
+++ b/pubtools/_quay/quay_api_client.py
@@ -2,8 +2,7 @@ import logging
 
 from .quay_session import QuaySession
 
-LOG = logging.getLogger()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class QuayApiClient:

--- a/pubtools/_quay/quay_client.py
+++ b/pubtools/_quay/quay_client.py
@@ -12,8 +12,7 @@ except ImportError:  # pragma: no cover
 from .exceptions import ManifestTypeError, RegistryAuthError
 from .quay_session import QuaySession
 
-LOG = logging.getLogger("PubLogger")
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class QuayClient:

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -9,9 +9,7 @@ from .utils.misc import (
     get_internal_container_repo_name,
 )
 
-LOG = logging.getLogger()
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 REMOVE_REPO_ARGS = {
     ("--repositories",): {
@@ -221,6 +219,8 @@ def remove_repositories(
 
 def remove_repositories_main(sysargs=None):
     """Entrypoint for removing repositories."""
+    logging.basicConfig(level=logging.INFO)
+
     parser = setup_arg_parser(REMOVE_REPO_ARGS)
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -12,9 +12,7 @@ from .quay_api_client import QuayApiClient
 from .quay_client import QuayClient
 from .manifest_claims_handler import ManifestClaimsHandler
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class SignatureHandler:

--- a/pubtools/_quay/signature_remover.py
+++ b/pubtools/_quay/signature_remover.py
@@ -10,9 +10,7 @@ from .utils.misc import (
 from .quay_api_client import QuayApiClient
 from .quay_client import QuayClient
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class SignatureRemover:

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -25,9 +25,7 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 
 class TagDocker:

--- a/pubtools/_quay/tag_images.py
+++ b/pubtools/_quay/tag_images.py
@@ -3,8 +3,7 @@ import logging
 from .utils.misc import setup_arg_parser, add_args_env_variables, send_umb_message
 from .command_executor import LocalExecutor, RemoteExecutor
 
-LOG = logging.getLogger("PubLogger")
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 TAG_IMAGES_ARGS = {
     ("--source-ref",): {
@@ -259,6 +258,8 @@ def verify_tag_images_args(
 
 def tag_images_main(sysargs=None):
     """Entrypoint for image tagging."""
+    logging.basicConfig(level=logging.INFO)
+
     parser = setup_arg_parser(TAG_IMAGES_ARGS)
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/pubtools/_quay/untag_images.py
+++ b/pubtools/_quay/untag_images.py
@@ -3,9 +3,7 @@ import logging
 from .image_untagger import ImageUntagger
 from .utils.misc import setup_arg_parser, add_args_env_variables, send_umb_message
 
-LOG = logging.getLogger()
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 UNTAG_IMAGES_ARGS = {
     ("--reference",): {
@@ -196,6 +194,8 @@ def untag_images(
 
 def untag_images_main(sysargs=None):
     """Entrypoint for untagging images."""
+    logging.basicConfig(level=logging.INFO)
+
     parser = setup_arg_parser(UNTAG_IMAGES_ARGS)
     if sysargs:
         args = parser.parse_args(sysargs[1:])

--- a/pubtools/_quay/utils/logger.py
+++ b/pubtools/_quay/utils/logger.py
@@ -6,7 +6,7 @@ class Logger(object):
 
     def __init__(self):
         """Init the logger instance."""
-        self.logger = logging.getLogger("PubLogger")
+        self.logger = logging.getLogger("pubtools.quay")
 
     def log_info(self, *args, **kwargs):
         """Log message with info level."""
@@ -41,7 +41,7 @@ def log_jsonl(step_name):
     :param step_name: Name of the task step, e.g., "Tag images".
     """
     event_name = step_name.lower().replace(" ", "-")
-    logger = logging.getLogger("PubLogger")
+    logger = logging.getLogger("pubtools.quay")
 
     def decorate(fn):
         def fn_wrapper(*args, **kwargs):

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -9,9 +9,7 @@ import textwrap
 
 from six import StringIO
 
-LOG = logging.getLogger("PubLogger")
-logging.basicConfig()
-LOG.setLevel(logging.INFO)
+LOG = logging.getLogger("pubtools.quay")
 
 INTERNAL_DELIMITER = "----"
 

--- a/tests/test_manifest_claims_handler.py
+++ b/tests/test_manifest_claims_handler.py
@@ -446,7 +446,7 @@ def test_on_message_not_last_one(mock_ssl_domain, mock_send_message, caplog):
 @mock.patch("pubtools._quay.manifest_claims_handler.ManifestClaimsHandler._send_message")
 @mock.patch("pubtools._quay.manifest_claims_handler.proton.SSLDomain")
 def test_on_message_unknown_message(mock_ssl_domain, mock_send_message, caplog):
-    caplog.set_level(logging.DEBUG, logger="PubLogger")
+    caplog.set_level(logging.DEBUG, logger="pubtools.quay")
     hub = mock.MagicMock()
     message_sender_callback = lambda messages: hub.worker.umb_send_manifest_claim_messages(
         "1", messages
@@ -534,7 +534,7 @@ def test_send_message(mock_ssl_domain, mock_monotonic):
 
 @mock.patch("pubtools._quay.manifest_claims_handler.proton.SSLDomain")
 def test_events_logs(mock_ssl_domain, caplog):
-    caplog.set_level(logging.DEBUG, logger="PubLogger")
+    caplog.set_level(logging.DEBUG, logger="pubtools.quay")
     hub = mock.MagicMock()
     event = mock.MagicMock()
 


### PR DESCRIPTION
We now have documented at [1] the preferred logger setup for
projects in the pubtools family. Tweak logger to be consistent with
that, which means:

- our logger should be named "pubtools.quay"

   - this ensures we can easily change logging config for this project
     specifically, or for all pubtools projects at once

- we should not set the level by default

   - this ensures that Pub's recently introduced support for controlling
     log levels in target settings will work correctly and not be
     overridden from within the project

   - (but basicConfig in a main function is OK because it does nothing
     if loggers are already configured)

[1] https://release-engineering.github.io/pubtools/devguide.html