### PR TITLE
refactor: use hooks to declare events of interest

### DIFF
--- a/pubtools/_quay/__init__.py
+++ b/pubtools/_quay/__init__.py
@@ -1,1 +1,6 @@
 """pubtools_quay."""
+
+# Ensure all hookspecs are declared.
+from . import hooks
+
+__all__ = ["hooks"]

--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -1,5 +1,7 @@
 import logging
 
+from pubtools.pluggy import task_context, pm
+
 from .signature_remover import SignatureRemover
 from .quay_client import QuayClient
 from .untag_images import untag_images
@@ -222,6 +224,8 @@ def clear_repositories(
     )
 
     LOG.info("Repositories have been cleared")
+    pm.hook.quay_repositories_cleared(repository_ids=sorted(parsed_repositories))
+
     if send_umb_msg:
         LOG.info("Sending a UMB message")
         props = {"cleared_repositories": parsed_repositories}
@@ -252,4 +256,6 @@ def clear_repositories_main(sysargs=None):
         raise ValueError("--quay-password must be specified")
 
     kwargs = construct_kwargs(args)
-    clear_repositories(**kwargs)
+
+    with task_context():
+        clear_repositories(**kwargs)

--- a/pubtools/_quay/hooks.py
+++ b/pubtools/_quay/hooks.py
@@ -1,0 +1,50 @@
+import sys
+
+from pubtools.pluggy import pm, hookspec
+
+# Define hooks here for any events which may be of interest for any other
+# projects in pubtools-*, or Pub.
+
+
+@hookspec
+def quay_repositories_cleared(repository_ids):
+    """Invoked after repositories have been cleared on Quay.
+
+    :param repository_ids: ID of each cleared repository.
+    :type repository_ids: list[str]
+    """
+
+
+@hookspec
+def quay_repositories_removed(repository_ids):
+    """Invoked after repositories have been removed from Quay.
+
+    :param repository_ids: ID of each removed repository.
+    :type repository_ids: list[str]
+    """
+
+
+@hookspec
+def quay_images_tagged(source_ref, dest_refs):
+    """Invoked after tagging image(s) on Quay.
+
+    :param source_ref: Source image reference.
+    :type source_ref: str
+    :param dest_refs: Destination image reference(s).
+    :type dest_refs: list[str]
+    """
+
+
+@hookspec
+def quay_images_untagged(untag_refs, lost_refs):
+    """Invoked after untagging image(s) on Quay.
+
+    :param untag_refs: Image references for which tags were removed.
+    :type untag_refs: list[str]
+    :param lost_refs: Image references (by digest) which are no longer reachable from any
+                      tag due to the untag operation.
+    :type lost_refs: list[str]
+    """
+
+
+pm.add_hookspecs(sys.modules[__name__])

--- a/pubtools/_quay/merge_manifest_list.py
+++ b/pubtools/_quay/merge_manifest_list.py
@@ -1,5 +1,7 @@
 import logging
 
+from pubtools.pluggy import task_context
+
 from .utils.misc import setup_arg_parser, add_args_env_variables
 from .manifest_list_merger import ManifestListMerger
 
@@ -74,4 +76,6 @@ def merge_manifest_list_main(sysargs=None):
         args.dest_quay_user,
         args.dest_quay_password,
     )
-    merger.merge_manifest_lists()
+
+    with task_context():
+        merger.merge_manifest_lists()

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -1,5 +1,7 @@
 import logging
 
+from pubtools.pluggy import pm, task_context
+
 from .signature_remover import SignatureRemover
 from .quay_api_client import QuayApiClient
 from .utils.misc import (
@@ -203,6 +205,8 @@ def remove_repositories(
         quay_api_client.delete_repository(internal_repo)
 
     LOG.info("Repositories have been removed")
+    pm.hook.quay_repositories_removed(repository_ids=sorted(parsed_repositories))
+
     if send_umb_msg:
         LOG.info("Sending a UMB message")
         props = {"removed_repositories": parsed_repositories}
@@ -233,4 +237,6 @@ def remove_repositories_main(sysargs=None):
         raise ValueError("--quay-password must be specified")
 
     kwargs = construct_kwargs(args)
-    remove_repositories(**kwargs)
+
+    with task_context():
+        remove_repositories(**kwargs)

--- a/pubtools/_quay/tag_images.py
+++ b/pubtools/_quay/tag_images.py
@@ -1,5 +1,7 @@
 import logging
 
+from pubtools.pluggy import pm, task_context
+
 from .utils.misc import setup_arg_parser, add_args_env_variables, send_umb_message
 from .command_executor import LocalExecutor, RemoteExecutor
 
@@ -218,6 +220,8 @@ def tag_images(
     executor.skopeo_login(quay_user, quay_password)
     executor.tag_images(source_ref, dest_refs, all_arch)
 
+    pm.hook.quay_images_tagged(source_ref=source_ref, dest_refs=sorted(dest_refs))
+
     if send_umb_msg:
         props = {"source_ref": source_ref, "dest_refs": dest_refs}
         send_umb_message(
@@ -268,4 +272,5 @@ def tag_images_main(sysargs=None):
     args = add_args_env_variables(args, TAG_IMAGES_ARGS)
 
     kwargs = construct_kwargs(args)
-    tag_images(**kwargs)
+    with task_context():
+        tag_images(**kwargs)

--- a/pubtools/_quay/untag_images.py
+++ b/pubtools/_quay/untag_images.py
@@ -1,5 +1,7 @@
 import logging
 
+from pubtools.pluggy import pm, task_context
+
 from .image_untagger import ImageUntagger
 from .utils.misc import setup_arg_parser, add_args_env_variables, send_umb_message
 
@@ -179,6 +181,8 @@ def untag_images(
     lost_images = untagger.untag_images()
 
     LOG.info("Untagging operation succeeded")
+    pm.hook.quay_images_untagged(untag_refs=sorted(references), lost_refs=sorted(lost_images))
+
     if send_umb_msg:
         LOG.info("Sending a UMB message")
         props = {"untag_refs": references, "lost_refs": lost_images}
@@ -207,4 +211,6 @@ def untag_images_main(sysargs=None):
         raise ValueError("--quay-api-token must be specified")
 
     kwargs = construct_kwargs(args)
-    untag_images(**kwargs)
+
+    with task_context():
+        untag_images(**kwargs)

--- a/requirements-py26.txt
+++ b/requirements-py26.txt
@@ -10,5 +10,6 @@ paramiko==2.3.1
 PyYAML < 5.1
 jsonschema == 2.3.0
 pyrsistent==0.13.0
+pluggy==0.5.2
 
 # -e git+https://code.engineering.redhat.com/gerrit/rhmsg#egg=rhmsg-0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pubtools-pyxis
 six
 python-qpid-proton==0.34.0
 monotonic
+pubtools>=0.3.0
 iiblib
 pubtools-iib
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,29 @@ except ImportError:
 import pytest
 from six import PY3
 
+from pubtools.pluggy import pm
+
 from pubtools._quay.utils.logger import Logger
 from .utils.caplog_compat import CapturelogWrapper
 
 # flake8: noqa: E501
+
+
+@pytest.fixture
+def hookspy():
+    # Yields a list which receives a (name, kwargs) tuple
+    # every time a pubtools hook is invoked.
+    hooks = []
+
+    def record_hook(hook_name, _hook_impls, kwargs):
+        hooks.append((hook_name, kwargs))
+
+    def do_nothing(*args, **kwargs):
+        pass
+
+    undo = pm.add_hookcall_monitoring(before=record_hook, after=do_nothing)
+    yield hooks
+    undo()
 
 
 @pytest.fixture

--- a/tests/test_clear_repo.py
+++ b/tests/test_clear_repo.py
@@ -283,7 +283,7 @@ def test_run(mock_quay_client, mock_send_umb_message, mock_signature_remover, mo
 @mock.patch("pubtools._quay.clear_repo.send_umb_message")
 @mock.patch("pubtools._quay.clear_repo.QuayClient")
 def test_run_multiple_repos(
-    mock_quay_client, mock_send_umb_message, mock_signature_remover, mock_untag_images
+    mock_quay_client, mock_send_umb_message, mock_signature_remover, mock_untag_images, hookspy
 ):
     args = [
         "dummy",
@@ -352,6 +352,16 @@ def test_run_multiple_repos(
         umb_ca_cert=None,
     )
     mock_send_umb_message.assert_not_called()
+
+    # Should have activated these hooks.
+    assert hookspy == [
+        ("task_start", {}),
+        (
+            "quay_repositories_cleared",
+            {"repository_ids": ["namespace/image", "namespace/image2"]},
+        ),
+        ("task_stop", {"failed": False}),
+    ]
 
 
 @mock.patch("pubtools._quay.clear_repo.untag_images")

--- a/tests/test_remove_repo.py
+++ b/tests/test_remove_repo.py
@@ -222,7 +222,7 @@ def test_args_missing_umb_cert(mock_quay_api_client, mock_send_umb_message):
 @mock.patch("pubtools._quay.remove_repo.SignatureRemover")
 @mock.patch("pubtools._quay.remove_repo.send_umb_message")
 @mock.patch("pubtools._quay.remove_repo.QuayApiClient")
-def test_run(mock_quay_api_client, mock_send_umb_message, mock_signature_remover):
+def test_run(mock_quay_api_client, mock_send_umb_message, mock_signature_remover, hookspy):
     args = [
         "dummy",
         "--repositories",
@@ -258,6 +258,12 @@ def test_run(mock_quay_api_client, mock_send_umb_message, mock_signature_remover
     )
     mock_delete_repo.assert_called_once_with("quay-organization/namespace----image")
     mock_send_umb_message.assert_not_called()
+
+    assert hookspy == [
+        ("task_start", {}),
+        ("quay_repositories_removed", {"repository_ids": ["namespace/image"]}),
+        ("task_stop", {"failed": False}),
+    ]
 
 
 @mock.patch("pubtools._quay.remove_repo.SignatureRemover")

--- a/tests/test_tag_entrypoint.py
+++ b/tests/test_tag_entrypoint.py
@@ -12,7 +12,7 @@ sys.modules["rhmsg.activemq.producer"] = module_mock
 
 
 @mock.patch("pubtools._quay.tag_images.LocalExecutor")
-def test_run_tag_entrypoint_local_success(mock_local_executor):
+def test_run_tag_entrypoint_local_success(mock_local_executor, hookspy):
     args = [
         "dummy",
         "--source-ref",
@@ -32,6 +32,18 @@ def test_run_tag_entrypoint_local_success(mock_local_executor):
     mock_tag_images.assert_called_once_with(
         "quay.io/repo/souce-image:1", ["quay.io/repo/target-image:1"], False
     )
+
+    assert hookspy == [
+        ("task_start", {}),
+        (
+            "quay_images_tagged",
+            {
+                "dest_refs": ["quay.io/repo/target-image:1"],
+                "source_ref": "quay.io/repo/souce-image:1",
+            },
+        ),
+        ("task_stop", {"failed": False}),
+    ]
 
 
 @mock.patch("pubtools._quay.tag_images.LocalExecutor")

--- a/tests/test_untag_images.py
+++ b/tests/test_untag_images.py
@@ -227,7 +227,7 @@ def test_send_umb_message(mock_send_umb_message, mock_image_untagger):
 
 @mock.patch("pubtools._quay.untag_images.send_umb_message")
 def test_full_run_remove_last(
-    mock_send_umb_message, manifest_list_data, v2s2_manifest_data, caplog
+    mock_send_umb_message, manifest_list_data, v2s2_manifest_data, caplog, hookspy
 ):
     args = [
         "dummy",
@@ -325,6 +325,25 @@ def test_full_run_remove_last(
             ca_cert="/path/to/ca_cert.crt",
             client_key="/path/to/umb.key",
         )
+
+    assert hookspy == [
+        ("task_start", {}),
+        (
+            "quay_images_untagged",
+            {
+                "lost_refs": [
+                    "quay.io/name/repo1@sha256:146ab6fa7ba3ab4d154b09c1c5522e4966ecd071bf23d1ba3df6c8b9fc33f8cb",
+                    "quay.io/name/repo1@sha256:2e8f38a0a8d2a450598430fa70c7f0b53aeec991e76c3e29c63add599b4ef7ee",
+                    "quay.io/name/repo1@sha256:496fb0ff2057c79254c9dc6ba999608a98219c5c93142569a547277c679e532c",
+                    "quay.io/name/repo1@sha256:836b8281def8a913eb3f1aeb4d12d372d77e11fb4bc5ebffe46a55552af5fc1f",
+                    "quay.io/name/repo1@sha256:b3f9218fb5839763e62e52ee6567fe331aa1f3c644f9b6f232ff23959257acf9",
+                    "quay.io/name/repo1@sha256:bbef1f46572d1f33a92b53b0ba0ed5a1d09dab7ffe64be1ae3ae66e76275eabd",
+                ],
+                "untag_refs": ["quay.io/name/repo1:1", "quay.io/name/repo1:2"],
+            },
+        ),
+        ("task_stop", {"failed": False}),
+    ]
 
 
 @mock.patch("pubtools._quay.untag_images.send_umb_message")

--- a/tox.ini
+++ b/tox.ini
@@ -38,4 +38,7 @@ commands =
 [flake8]
 ignore = D100,D104,W503
 max-line-length = 100
-per-file-ignores = tests/*:D103
+per-file-ignores =
+    tests/*:D103
+    # "D401 First line should be in imperative mood" -> hooks are not like typical functions
+    pubtools/_quay/hooks.py:D401


### PR DESCRIPTION
pubtools library includes a hook/event system. Use that to
declare hooks which may be of interest to Pub.

The primary motivation for this right now is to address some
problems with the UMB message sending, hence the addition of one
hook nearby each point where a UMB message could be sent.

The idea is to do the following:

1. add these hooks in pubtools-quay
2. make Pub connect to these hooks and send UMB messages
3. drop the UMB sending code from pubtools-quay

The main reason for this is that pubtools-quay simply doesn't have
access to all the needed information in order to send appropriate
messages. For example, it does not know a Pub task ID, a Pub target or
the name of the user who requested the task, all of which should be
included.

Another reason is that each project should not have to independently
deal with the necessary logic for connecting to UMB and sending
messages. As can be seen in pubtools-quay, the amount of code needed to
do that (and test it) is far from trivial.