### PR TITLE
Get index image manifests with its own token

### DIFF
--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -542,7 +542,13 @@ class OperatorSignatureHandler(SignatureHandler):
         image_schema = "{host}/{repository}:{tag}"
 
         # Get digests of all archs this index image was build for
-        manifest_list = self.src_quay_client.get_manifest(index_image, manifest_list=True)
+        index_image_credential = self.target_settings["iib_overwrite_from_index_token"].split(":")
+        index_image_quay_client = QuayClient(
+            index_image_credential[0],
+            index_image_credential[1],
+            self.quay_host,
+        )
+        manifest_list = index_image_quay_client.get_manifest(index_image, manifest_list=True)
         digests = [m["digest"] for m in manifest_list["manifests"]]
         for registry in self.dest_registries:
             for signing_key in signing_keys:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -585,7 +585,7 @@ def target_settings():
         "ssh_user": "ssh-user",
         "ssh_password": "ssh-password",
         "iib_overwrite_from_index": True,
-        "iib_overwrite_from_index_token": "some-token",
+        "iib_overwrite_from_index_token": "some-user:some-pass",
         "skopeo_image": "registry.com/some/image:1",
     }
 

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -175,7 +175,7 @@ def test_iib_add_bundles_str_deprecation_list(
             "--deprecation-list",
             "bundle3,bundle4",
         ],
-        {"OVERWRITE_FROM_INDEX_TOKEN": "some-token"},
+        {"OVERWRITE_FROM_INDEX_TOKEN": "some-user:some-pass"},
     )
 
 
@@ -219,7 +219,7 @@ def test_iib_add_bundles_list_deprecation_list(
             "--deprecation-list",
             "bundle3,bundle4",
         ],
-        {"OVERWRITE_FROM_INDEX_TOKEN": "some-token"},
+        {"OVERWRITE_FROM_INDEX_TOKEN": "some-user:some-pass"},
     )
 
 
@@ -258,7 +258,7 @@ def test_iib_remove_operators(mock_run_entrypoint, target_settings, operator_pus
             "--arch",
             "arch2",
         ],
-        {"OVERWRITE_FROM_INDEX_TOKEN": "some-token"},
+        {"OVERWRITE_FROM_INDEX_TOKEN": "some-user:some-pass"},
     )
 
 


### PR DESCRIPTION
In case iib_index_image is in a different organization from
source quay organization, use iib_overwrite_from_index_token
to get manifests of it for signing.