### PR TITLE
Replace "docker" dependency with "docker-py" when building an RPM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,11 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 
+# same dependency is called "docker-py" in for Python 2.6 and "docker" on newer Python versions
+# Thus, it has to be removed from the list of requirements and added under a different name
+RPM_BLACKLISTED_DEPENDENCIES = ["docker"]
+RPM_EXTRA_DEPENDENCIES = ["docker-py"]
+
 def building_rpm():
     """True when running within RPM build environment, which tweaks
     the build a little."""
@@ -68,6 +73,9 @@ def get_requirements():
     # If we are building an RPM, we don't have pip available, and we want
     # to use the 'name + dependency_link' style
     if building_rpm():
+        reqs = [d for d in reqs if d not in RPM_BLACKLISTED_DEPENDENCIES]
+        reqs.extend(RPM_EXTRA_DEPENDENCIES)
+        reqs = sorted(list(set(reqs)))
         pip_version = [0, 0, 0]
     else:
         import pip

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+import sys
 
 # import pkg_resources
 import sys
@@ -53,8 +54,8 @@ classifiers = [
 
 # same dependency is called "docker-py" in for Python 2.6 and "docker" on newer Python versions
 # Thus, it has to be removed from the list of requirements and added under a different name
-RPM_BLACKLISTED_DEPENDENCIES = ["docker"]
-RPM_EXTRA_DEPENDENCIES = ["docker-py"]
+PY26_BLACKLISTED_DEPENDENCIES = ["docker"]
+PY26_EXTRA_DEPENDENCIES = ["docker-py"]
 
 def building_rpm():
     """True when running within RPM build environment, which tweaks
@@ -70,11 +71,14 @@ def get_requirements():
     """
     with open("requirements.txt") as f:
         reqs = f.read().splitlines()
+    
+    if sys.version_info < (2, 7):
+        reqs = [d for d in reqs if d not in PY26_BLACKLISTED_DEPENDENCIES]
+        reqs.extend(PY26_EXTRA_DEPENDENCIES)
+
     # If we are building an RPM, we don't have pip available, and we want
     # to use the 'name + dependency_link' style
     if building_rpm():
-        reqs = [d for d in reqs if d not in RPM_BLACKLISTED_DEPENDENCIES]
-        reqs.extend(RPM_EXTRA_DEPENDENCIES)
         reqs = sorted(list(set(reqs)))
         pip_version = [0, 0, 0]
     else:


### PR DESCRIPTION
Python 2.6 and pub use "docker-py" dependency, which has since been
renamed to "docker". Thus, when building an RPM, "docker-py" name
should be used, because otherwise the entrypoint resolution fails
due to "docker" not being installed. The current implementation
still alows for a normal pip instllation on a newer platform.