### PR TITLE
Simplify signature upload to only call pubtools-pyxis once

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,14 @@ deps =
 commands =
     black -l 100 --check --diff pubtools tests
 
+[testenv:black-format]
+description = black checks
+basepython = python3
+deps =
+    black
+commands =
+    black -l 100 pubtools tests
+
 [testenv:docs]
 basepython = python3
 deps=


### PR DESCRIPTION
Since batch upload is no longer supported, pubtools-pyxis can now
only be called once with all the signatures.

An unrelated change is adding black formatting to tox.ini, allowing
developers to to automatically apply black formatting via tox.

Refers to CLOUDDST-8363