### PR TITLE
Fix calls to remove signatures in push_docker.py

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -449,12 +449,14 @@ class PushDocker:
             ) not in new_signatures:
                 signatures_to_remove.append(esig["_id"])
 
+        cert, key = get_pyxis_ssl_paths(self.target_settings)
+
         if signatures_to_remove:
             signature_remover.remove_signatures_from_pyxis(
                 signatures_to_remove,
                 self.target_settings["pyxis_server"],
-                self.target_settings["iib_krb_principal"],
-                self.target_settings["iib_krb_ktfile"],
+                cert,
+                key,
             )
 
         signatures_to_remove = []
@@ -494,8 +496,8 @@ class PushDocker:
                 signature_remover.remove_signatures_from_pyxis(
                     signatures_to_remove,
                     self.target_settings["pyxis_server"],
-                    self.target_settings["iib_krb_principal"],
-                    self.target_settings["iib_krb_ktfile"],
+                    cert,
+                    key,
                 )
 
     def run(self):

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -925,6 +925,7 @@ def test_push_docker_full_success(
     container_multiarch_push_item,
     container_push_item_external_repos,
     operator_push_item_ok,
+    fake_cert_key_paths,
 ):
     hub = mock.MagicMock()
     mock_push_container_images = mock.MagicMock()
@@ -1033,6 +1034,7 @@ def test_push_docker_full_success_repush(
     container_multiarch_push_item,
     container_push_item_external_repos,
     operator_push_item_ok,
+    fake_cert_key_paths,
 ):
     hub = mock.MagicMock()
     mock_push_container_images = mock.MagicMock()
@@ -1149,6 +1151,7 @@ def test_push_docker_no_operator_push_items(
     mock_rollback,
     target_settings,
     container_multiarch_push_item,
+    fake_cert_key_paths,
 ):
     hub = mock.MagicMock()
     mock_push_container_images = mock.MagicMock()
@@ -1325,6 +1328,7 @@ def test_remove_old_signatures_no_old_signatures(
     mock_container_signature_handler,
     patched_verify_target_settings,
     container_push_item_external_repos,
+    fake_cert_key_paths,
 ):
     backup_tags = {}
     image_data = push_docker.PushDocker.ImageData(
@@ -1375,6 +1379,7 @@ def test_remove_old_signatures_container_signatures(
     mock_container_signature_handler,
     patched_verify_target_settings,
     container_push_item_external_repos,
+    fake_cert_key_paths,
 ):
     mock_get_signatures_from_pyxis = mock.MagicMock(
         return_value=(
@@ -1417,7 +1422,7 @@ def test_remove_old_signatures_container_signatures(
         mock_signature_remover,
     )
     mock_signature_remover.remove_signatures_from_pyxis.assert_called_with(
-        ["signature-id-1"], "mock_pyxis_server", "mock_pyxis_principal", "mock_pyxis_krb_ktfile"
+        ["signature-id-1"], "mock_pyxis_server", "/path/to/file.crt", "/path/to/file.key"
     )
 
 
@@ -1432,6 +1437,7 @@ def test_remove_old_signatures_operator_signatures(
     patched_verify_target_settings,
     container_push_item_external_repos,
     operator_push_item_ok,
+    fake_cert_key_paths,
 ):
     mock_get_signatures_from_pyxis = mock.MagicMock(
         side_effect=[
@@ -1461,13 +1467,18 @@ def test_remove_old_signatures_operator_signatures(
         "reference/some-product----some-repo", "someversion", None
     )
     backup_tags[image_data] = {"digest": "some-digest"}
+    mock_target_settings = {
+        "pyxis_server": "mock_pyxis_server",
+        "iib_krb_principal": "mock_pyxis_principal",
+        "iib_krb_ktfile": "mock_pyxis_krb_ktfile",
+    }
 
     push_docker.PushDocker(
         [container_push_item_external_repos],
         mock.MagicMock(),
         mock.MagicMock(),
         mock.MagicMock(),
-        mock.MagicMock(),
+        mock_target_settings,
     ).remove_old_signatures(
         [container_push_item_external_repos],
         [operator_push_item_ok],
@@ -1483,9 +1494,7 @@ def test_remove_old_signatures_operator_signatures(
         mock_operator_signature_handler,
         mock_signature_remover,
     )
-    mock_container_signature_handler.remove_signatures_from_pyxis.has_calls(
-        mock.call(["signature-id-1"])
-    )
-    mock_container_signature_handler.remove_signatures_from_pyxis.has_calls(
-        mock.call(["signature-id-2"])
+
+    mock_signature_remover.remove_signatures_from_pyxis.assert_called_once_with(
+        ["signature-id-2"], "mock_pyxis_server", "/path/to/file.crt", "/path/to/file.key"
     )

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ commands =
     black -l 100 --check --diff pubtools tests
 
 [testenv:black-format]
-description = black checks
+description = apply black formatting
 basepython = python3
 deps =
     black


### PR DESCRIPTION
Calls weren't previously fixed to be invoked with SSL certificate paths instead of Kerberos credentials.

Refers to CLOUDDST-5733