### PR TITLE
Remove duplicate digests when getting signatures from Pyxis

### DIFF
--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -158,6 +158,7 @@ class SignatureHandler:
         """
         cert, key = get_pyxis_ssl_paths(self.target_settings)
         chunk_size = self.MAX_MANIFEST_DIGESTS_PER_SEARCH_REQUEST
+        manifest_digests = sorted(list(set(manifest_digests)))
 
         for chunk_start in range(0, len(manifest_digests), chunk_size):
             chunk = manifest_digests[chunk_start : chunk_start + chunk_size]  # noqa: E203

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -139,7 +139,7 @@ def test_get_pyxis_signature(
     sig_handler = signature_handler.SignatureHandler(hub, "1", target_settings, "some-target")
     sig_handler.MAX_MANIFEST_DIGESTS_PER_SEARCH_REQUEST = 2
     sig_data = sig_handler.get_signatures_from_pyxis(
-        ["sha256:a1a1a1a1a", "sha256:b2b2b2b2", "sha256:c3c3c3c3"]
+        ["sha256:a1a1a1a1a", "sha256:b2b2b2b2", "sha256:c3c3c3c3", "sha256:c3c3c3c3"]
     )
     for i, data in enumerate(sig_data):
         assert data == (expected_data1 + expected_data2)[i]


### PR DESCRIPTION
As an unrelated change, SignatureRemover's Pyxis wrapper for getting
signatures was updated to use JSON file instead of writing the
signatures to the command invocation. Seemingly, this change was
previously forgotten about.

Refers to CLOUDDST-8473