### PR TITLE
Tag and sign timestamp for pushed index images

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -130,7 +130,7 @@ def task_iib_add_bundles(
     index_stamp = timestamp()
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings, target_name)
     claim_messages = sig_handler.sign_task_index_image(
-        signing_keys, intermediate_index_image, tag, "%s-%s" % (tag, index_stamp)
+        signing_keys, intermediate_index_image, [tag, "%s-%s" % (tag, index_stamp)]
     )
 
     sig_remover = SignatureRemover(
@@ -228,7 +228,7 @@ def task_iib_remove_operators(
     index_stamp = timestamp()
     sig_handler = OperatorSignatureHandler(hub, task_id, target_settings, target_name)
     claim_messages = sig_handler.sign_task_index_image(
-        signing_keys, intermediate_index_image, tag, "%s-%s" % (tag, index_stamp)
+        signing_keys, intermediate_index_image, [tag, "%s-%s" % (tag, index_stamp)]
     )
 
     sig_remover = SignatureRemover(
@@ -331,8 +331,7 @@ def task_iib_build_from_scratch(
     sig_handler.sign_task_index_image(
         signing_keys,
         intermediate_index_image,
-        index_image_tag,
-        "%s-%s" % (index_image_tag, index_stamp),
+        [index_image_tag, "%s-%s" % (index_image_tag, index_stamp)],
     )
 
     # Push image to Quay

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -414,13 +414,15 @@ class OperatorPusher:
         return iib_results
 
     @log_step("Push index images to Quay")
-    def push_index_images(self, iib_results, timestamp=None):
+    def push_index_images(self, iib_results, tag_suffix=None):
         """
         Push index images which were built in the previous stage to Quay.
 
         Args:
             iib_results (dict):
                 IIB results returned by the build stage
+            tag_suffix (str):
+                extra tag suffix applied to iib version tags if specified
         """
         image_schema = "{host}/{namespace}/{repo}"
         index_image_repo = image_schema.format(
@@ -437,8 +439,8 @@ class OperatorPusher:
             ContainerImagePusher.run_tag_images(
                 build_details.index_image, [dest_image], True, self.target_settings
             )
-            if timestamp:
-                dest_image = "{0}:{1}-{2}".format(index_image_repo, tag, timestamp)
+            if tag_suffix:
+                dest_image = "{0}:{1}-{2}".format(index_image_repo, tag, tag_suffix)
                 ContainerImagePusher.run_tag_images(
                     build_details.index_image, [dest_image], True, self.target_settings
                 )

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -414,7 +414,7 @@ class OperatorPusher:
         return iib_results
 
     @log_step("Push index images to Quay")
-    def push_index_images(self, iib_results):
+    def push_index_images(self, iib_results, timestamp=None):
         """
         Push index images which were built in the previous stage to Quay.
 
@@ -437,3 +437,8 @@ class OperatorPusher:
             ContainerImagePusher.run_tag_images(
                 build_details.index_image, [dest_image], True, self.target_settings
             )
+            if timestamp:
+                dest_image = "{0}:{1}-{2}".format(index_image_repo, tag, timestamp)
+                ContainerImagePusher.run_tag_images(
+                    build_details.index_image, [dest_image], True, self.target_settings
+                )

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -474,7 +474,7 @@ class PushDocker:
                 )
                 ii_claim_messages += (
                     operator_signature_handler.construct_index_image_claim_messages(
-                        intermediate_index_image, version, None, signing_keys
+                        intermediate_index_image, [version], signing_keys
                     )
                 )
             new_operator_signatures = [

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -11,7 +11,7 @@ from .container_image_pusher import ContainerImagePusher
 from .signature_handler import ContainerSignatureHandler, OperatorSignatureHandler
 from .signature_remover import SignatureRemover
 from .operator_pusher import OperatorPusher
-from .utils.misc import get_external_container_repo_name, get_pyxis_ssl_paths
+from .utils.misc import get_external_container_repo_name, get_pyxis_ssl_paths, timestamp
 
 # TODO: do we want this, or should I remove it?
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
@@ -474,7 +474,7 @@ class PushDocker:
                 )
                 ii_claim_messages += (
                     operator_signature_handler.construct_index_image_claim_messages(
-                        intermediate_index_image, version, signing_keys
+                        intermediate_index_image, version, None, signing_keys
                     )
                 )
             new_operator_signatures = [
@@ -529,7 +529,7 @@ class PushDocker:
         backup_tags, rollback_tags = self.generate_backup_mapping(docker_push_items)
         existing_index_images = []
         iib_results = None
-
+        index_stamp = timestamp()
         try:
             # Sign container images
             container_signature_handler = ContainerSignatureHandler(
@@ -554,9 +554,9 @@ class PushDocker:
                 )
                 iib_results = operator_pusher.build_index_images()
                 # Sign operator images
-                operator_signature_handler.sign_operator_images(iib_results)
+                operator_signature_handler.sign_operator_images(iib_results, index_stamp)
                 # Push index images to Quay
-                operator_pusher.push_index_images(iib_results)
+                operator_pusher.push_index_images(iib_results, index_stamp)
         except (Exception, SystemExit):
             LOG.error("An exception has occurred during the push, starting rollback")
             self.rollback(backup_tags, rollback_tags)

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -7,6 +7,7 @@ import os
 import pkg_resources
 import sys
 import textwrap
+import time
 
 from six import StringIO
 from pubtools.pluggy import pm
@@ -317,3 +318,8 @@ def get_pyxis_ssl_paths(target_settings):
         key = target_settings["pyxis_ssl_key"]
 
     return (cert, key)
+
+
+def timestamp():
+    """Return now() timestamp."""
+    return str(time.time()).split(".")[0]

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -38,7 +38,9 @@ def test_verify_target_settings_overwrite_index_mismatch(target_settings):
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
 @mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
 def test_task_iib_add_bundles(
+    mock_timestamp,
     mock_verify_target_settings,
     mock_iib_add_bundles,
     mock_run_tag_images,
@@ -47,6 +49,7 @@ def test_task_iib_add_bundles(
     target_settings,
     fake_cert_key_paths,
 ):
+    mock_timestamp.return_value = "timestamp"
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -92,7 +95,10 @@ def test_task_iib_add_bundles(
     )
     mock_run_tag_images.assert_called_once_with(
         "some-registry.com/iib-namespace/new-index-image:8",
-        ["quay.io/some-namespace/operators----index-image:8"],
+        [
+            "quay.io/some-namespace/operators----index-image:8",
+            "quay.io/some-namespace/operators----index-image:8-timestamp",
+        ],
         True,
         target_settings,
     )
@@ -100,7 +106,7 @@ def test_task_iib_add_bundles(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8", "8-timestamp"
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -123,7 +129,9 @@ def test_task_iib_add_bundles(
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_remove_operators")
 @mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
 def test_task_iib_remove_operators(
+    mock_timestamp,
     mock_verify_target_settings,
     mock_iib_remove_operators,
     mock_run_tag_images,
@@ -132,6 +140,7 @@ def test_task_iib_remove_operators(
     target_settings,
     fake_cert_key_paths,
 ):
+    mock_timestamp.return_value = "timestamp"
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -175,7 +184,10 @@ def test_task_iib_remove_operators(
     )
     mock_run_tag_images.assert_called_once_with(
         "some-registry.com/iib-namespace/new-index-image:8",
-        ["quay.io/some-namespace/operators----index-image:8"],
+        [
+            "quay.io/some-namespace/operators----index-image:8",
+            "quay.io/some-namespace/operators----index-image:8-timestamp",
+        ],
         True,
         target_settings,
     )
@@ -183,7 +195,7 @@ def test_task_iib_remove_operators(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8", "8-timestamp"
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -205,13 +217,16 @@ def test_task_iib_remove_operators(
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
 @mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
 def test_task_iib_build_from_scratch(
+    mock_timestamp,
     mock_verify_target_settings,
     mock_iib_add_bundles,
     mock_run_tag_images,
     mock_operator_signature_handler,
     target_settings,
 ):
+    mock_timestamp.return_value = "timestamp"
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
@@ -241,7 +256,10 @@ def test_task_iib_build_from_scratch(
     )
     mock_run_tag_images.assert_called_once_with(
         "some-registry.com/iib-namespace/new-index-image:8",
-        ["quay.io/some-namespace/operators----index-image:12"],
+        [
+            "quay.io/some-namespace/operators----index-image:12",
+            "quay.io/some-namespace/operators----index-image:12-timestamp",
+        ],
         True,
         target_settings,
     )
@@ -249,7 +267,7 @@ def test_task_iib_build_from_scratch(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "12"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "12", "12-timestamp"
     )
 
 

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -106,7 +106,7 @@ def test_task_iib_add_bundles(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8", "8-timestamp"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -195,7 +195,7 @@ def test_task_iib_remove_operators(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "8", "8-timestamp"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -267,7 +267,7 @@ def test_task_iib_build_from_scratch(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", "12", "12-timestamp"
+        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["12", "12-timestamp"]
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -949,7 +949,9 @@ def test_tag_docker_source_copy_untag(
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+@mock.patch("pubtools._quay.utils.misc.timestamp")
 def test_task_iib_add_bundles(
+    mock_timestamp,
     mock_run_entrypoint_operator_pusher,
     mock_manifest_claims_handler,
     mock_run_entrypoint_signature_handler,
@@ -966,6 +968,7 @@ def test_task_iib_add_bundles(
             self.index_image = index_image
             self.index_image_resolved = index_image_resolved
 
+    mock_timestamp.return_value = "timestamp"
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -898,6 +898,7 @@ def test_rollback_delete_tag_server_error(
     mock_delete_tag.assert_called_once_with("some-namespace/target----repo3", "3")
 
 
+@mock.patch("pubtools._quay.push_docker.timestamp")
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
 @mock.patch("pubtools._quay.push_docker.OperatorSignatureHandler")
 @mock.patch("pubtools._quay.push_docker.OperatorPusher")
@@ -921,6 +922,7 @@ def test_push_docker_full_success(
     mock_operator_pusher,
     mock_operator_signature_handler,
     mock_rollback,
+    mock_timestamp,
     target_settings,
     container_multiarch_push_item,
     container_push_item_external_repos,
@@ -952,6 +954,7 @@ def test_push_docker_full_success(
     mock_operator_pusher.return_value.push_index_images = mock_push_index_images
     mock_sign_operator_images = mock.MagicMock(return_value=([], []))
     mock_operator_signature_handler.return_value.sign_operator_images = mock_sign_operator_images
+    mock_timestamp.return_value = "timestamp"
 
     mock_get_docker_push_items.return_value = [container_multiarch_push_item]
     mock_get_operator_push_items.return_value = [operator_push_item_ok]
@@ -994,18 +997,19 @@ def test_push_docker_full_success(
     mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with(
-        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
     )
     mock_operator_signature_handler.assert_called_once_with(
         hub, "1", target_settings, "some-target"
     )
     mock_sign_operator_images.assert_called_once_with(
-        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
     )
     mock_rollback.assert_not_called()
     assert repos == ["test_repo"]
 
 
+@mock.patch("pubtools._quay.push_docker.timestamp")
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
 @mock.patch("pubtools._quay.push_docker.OperatorSignatureHandler")
 @mock.patch("pubtools._quay.push_docker.OperatorPusher")
@@ -1029,6 +1033,7 @@ def test_push_docker_full_success_repush(
     mock_operator_pusher,
     mock_operator_signature_handler,
     mock_rollback,
+    mock_timestamp,
     target_settings,
     container_multiarch_push_item,
     container_push_item_external_repos,
@@ -1046,6 +1051,7 @@ def test_push_docker_full_success_repush(
     mock_get_existing_index_images = mock.MagicMock(
         return_value=[("somerepo", "somedigest", "sometag")]
     )
+    mock_timestamp.return_value = "timestamp"
     mock_operator_pusher.return_value.get_existing_index_images = mock_get_existing_index_images
     mock_sign_operator_images = mock.MagicMock(
         return_value=(
@@ -1112,13 +1118,13 @@ def test_push_docker_full_success_repush(
     mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with(
-        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
     )
     mock_operator_signature_handler.assert_called_once_with(
         hub, "1", target_settings, "some-target"
     )
     mock_sign_operator_images.assert_called_once_with(
-        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
     )
     mock_rollback.assert_not_called()
     assert repos == ["test_repo"]

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -579,7 +579,7 @@ def test_construct_operator_item_claim_messages(
     )
 
     claim_messages = sig_handler.construct_index_image_claim_messages(
-        operator_signing_push_item, "v4.5", None, ["key1", "key2"]
+        operator_signing_push_item, ["v4.5"], ["key1", "key2"]
     )
 
     with open("tests/test_data/test_expected_operator_claim_messages.json", "r") as f:
@@ -700,10 +700,10 @@ def test_sign_task_index_image(
         hub, "1", target_settings, "some-target"
     )
     claims = sig_handler.sign_task_index_image(
-        ["some-key"], "registry1/namespace/image:1", "3", "3-stamp"
+        ["some-key"], "registry1/namespace/image:1", ["3", "3-stamp"]
     )
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "registry1/namespace/image:1", "3", "3-stamp", ["some-key"]
+        "registry1/namespace/image:1", ["3", "3-stamp"], ["some-key"]
     )
     mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2"])
     mock_validate_radas_msgs.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"])
@@ -849,7 +849,7 @@ def test_construct_operator_item_claim_messages_none_signing_key(
     )
 
     claim_messages = sig_handler.construct_index_image_claim_messages(
-        operator_signing_push_item, "v4.5", "v4.5-stamp", [None]
+        operator_signing_push_item, ["v4.5", "v4.5-stamp"], [None]
     )
 
     assert claim_messages == []
@@ -888,7 +888,7 @@ def test_sign_operator_images_no_signatures(
     )
     sig_handler.sign_operator_images(iib_results, "stamp")
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", "v4.5-stamp", [None]
+        "quay.io/iib-namespace/iib@sha256:a1a1a1", ["v4.5", "v4.5-stamp"], [None]
     )
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()
@@ -916,9 +916,9 @@ def test_sign_task_index_image_no_signatures(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    sig_handler.sign_task_index_image([None], "registry1/namespace/image:1", "3", "3-stamp")
+    sig_handler.sign_task_index_image([None], "registry1/namespace/image:1", ["3", "3-stamp"])
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "registry1/namespace/image:1", "3", "3-stamp", [None]
+        "registry1/namespace/image:1", ["3", "3-stamp"], [None]
     )
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -579,7 +579,7 @@ def test_construct_operator_item_claim_messages(
     )
 
     claim_messages = sig_handler.construct_index_image_claim_messages(
-        operator_signing_push_item, "v4.5", ["key1", "key2"]
+        operator_signing_push_item, "v4.5", None, ["key1", "key2"]
     )
 
     with open("tests/test_data/test_expected_operator_claim_messages.json", "r") as f:
@@ -626,13 +626,13 @@ def test_sign_operator_images(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    sig_handler.sign_operator_images(iib_results)
+    sig_handler.sign_operator_images(iib_results, "stamp-tag")
     assert mock_construct_index_claim_msgs.call_count == 2
     mock_construct_index_claim_msgs.call_args_list[0] == mock.call(
-        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", ["key1"]
+        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", "v4.5-stamp-tag", ["key1"]
     )
     mock_construct_index_claim_msgs.call_args_list[0] == mock.call(
-        "quay.io/iib-namespace/iib@sha256:b2b2b2", "v4.6", ["key2"]
+        "quay.io/iib-namespace/iib@sha256:b2b2b2", "v4.6", "v4.6-stamp-tag", ["key2"]
     )
     mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])
     mock_validate_radas_msgs.assert_called_once_with(
@@ -665,7 +665,7 @@ def test_sign_operator_images_not_allowed(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    sig_handler.sign_operator_images({"nothing": "here"})
+    sig_handler.sign_operator_images({"nothing": "here"}, "stamp-tag")
     mock_construct_index_claim_msgs.assert_not_called()
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()
@@ -699,9 +699,11 @@ def test_sign_task_index_image(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    claims = sig_handler.sign_task_index_image(["some-key"], "registry1/namespace/image:1", "3")
+    claims = sig_handler.sign_task_index_image(
+        ["some-key"], "registry1/namespace/image:1", "3", "3-stamp"
+    )
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "registry1/namespace/image:1", "3", ["some-key"]
+        "registry1/namespace/image:1", "3", "3-stamp", ["some-key"]
     )
     mock_get_radas_signatures.assert_called_once_with(["msg1", "msg2"])
     mock_validate_radas_msgs.assert_called_once_with(["msg1", "msg2"], ["sig1", "sig2"])
@@ -847,7 +849,7 @@ def test_construct_operator_item_claim_messages_none_signing_key(
     )
 
     claim_messages = sig_handler.construct_index_image_claim_messages(
-        operator_signing_push_item, "v4.5", [None]
+        operator_signing_push_item, "v4.5", "v4.5-stamp", [None]
     )
 
     assert claim_messages == []
@@ -884,9 +886,9 @@ def test_sign_operator_images_no_signatures(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    sig_handler.sign_operator_images(iib_results)
+    sig_handler.sign_operator_images(iib_results, "stamp")
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", [None]
+        "quay.io/iib-namespace/iib@sha256:a1a1a1", "v4.5", "v4.5-stamp", [None]
     )
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()
@@ -914,9 +916,9 @@ def test_sign_task_index_image_no_signatures(
     sig_handler = signature_handler.OperatorSignatureHandler(
         hub, "1", target_settings, "some-target"
     )
-    sig_handler.sign_task_index_image([None], "registry1/namespace/image:1", "3")
+    sig_handler.sign_task_index_image([None], "registry1/namespace/image:1", "3", "3-stamp")
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "registry1/namespace/image:1", "3", [None]
+        "registry1/namespace/image:1", "3", "3-stamp", [None]
     )
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()


### PR DESCRIPTION
In order to avoid garbage collection of old tags for index images
which are regularly overwritten by every push, timestmap tags are
used to create unique tag for every index image pushed.
Timestamp tags are applied per index image version in format
version-stamp, for example: v4.9-1630072512