### PR TITLE
Remove return of push_docker entry point

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -514,9 +514,6 @@ class PushDocker:
         - Push the index images to Quay
         - Remove outdated container signatures
         - (in case of failure) Rollback destination repos to the pre-push state
-
-        Returns ([str]):
-            List of container image repos (for UD cache flush done by pub)
         """
         # TODO: Do we need to manage push item state?
         # Filter out non-docker push items
@@ -574,15 +571,8 @@ class PushDocker:
                 sig_remover,
             )
 
-        # Return repos for UD cache flush
-        repos = []
-        for item in docker_push_items:
-            repos += item.repos.keys()
-
-        return sorted(list(set(repos)))
-
 
 def mod_entry_point(push_items, hub, task_id, target_name, target_settings):
     """Entry point for use in another python code."""
     push = PushDocker(push_items, hub, task_id, target_name, target_settings)
-    return push.run()
+    push.run()

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -976,7 +976,7 @@ def test_push_docker_full_success(
         "some-target",
         target_settings,
     )
-    repos = push_docker_instance.run()
+    push_docker_instance.run()
 
     mock_get_docker_push_items.assert_called_once_with()
     mock_check_repos_validity.assert_called_once_with(
@@ -1003,7 +1003,6 @@ def test_push_docker_full_success(
         {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
     )
     mock_rollback.assert_not_called()
-    assert repos == ["test_repo"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -1087,7 +1086,7 @@ def test_push_docker_full_success_repush(
         "some-target",
         target_settings,
     )
-    repos = push_docker_instance.run()
+    push_docker_instance.run()
 
     mock_get_docker_push_items.assert_called_once_with()
     mock_get_docker_push_items.assert_called_once_with()
@@ -1121,7 +1120,6 @@ def test_push_docker_full_success_repush(
         {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
     )
     mock_rollback.assert_not_called()
-    assert repos == ["test_repo"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -1176,7 +1174,7 @@ def test_push_docker_no_operator_push_items(
     push_docker_instance = push_docker.PushDocker(
         [container_multiarch_push_item], hub, "1", "some-target", target_settings
     )
-    repos = push_docker_instance.run()
+    push_docker_instance.run()
 
     mock_get_docker_push_items.assert_called_once_with()
     mock_get_docker_push_items.assert_called_once_with()
@@ -1197,7 +1195,6 @@ def test_push_docker_no_operator_push_items(
     mock_push_index_images.assert_not_called()
     mock_sign_operator_images.assert_not_called()
     mock_rollback.assert_not_called()
-    assert repos == ["test_repo"]
 
 
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -1298,7 +1295,7 @@ def test_mod_entrypoint(
     mock_run.return_value = ["repo1", "repo2"]
     mock_push_docker.return_value.run = mock_run
 
-    repos = push_docker.mod_entry_point(
+    push_docker.mod_entry_point(
         [container_multiarch_push_item, operator_push_item_ok],
         hub,
         "1",


### PR DESCRIPTION
UD cache flush for quay target has been removed from Pub, repos
returned by push_docker become useless. So remove the return.