### PR TITLE
Get container push items by unique pull_url

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -613,7 +613,7 @@ def container_source_push_item():
             "destination": {"tags": {"repo": ["tag1"]}},
             "tags": {"target/repo": ["latest-test-tag", "1.0"]},
             "v_r": "1.0",
-            "pull_url": "some-registry/src/repo:1",
+            "pull_url": "some-registry/src/repo:2",
             "build": {"extra": {"image": {"sources_for_nvr": "some-src"}}},
         },
     )

--- a/tests/test_container_pusher.py
+++ b/tests/test_container_pusher.py
@@ -79,7 +79,7 @@ def test_copy_src_item(
     )
     pusher.copy_source_push_item(container_source_push_item)
     mock_tag_images.assert_called_once_with(
-        "some-registry/src/repo:1",
+        "some-registry/src/repo:2",
         [
             "quay.io/some-namespace/target----repo:latest-test-tag",
             "quay.io/some-namespace/target----repo:1.0",

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -122,7 +122,12 @@ def test_get_container_push_items_ok(
 ):
     hub = mock.MagicMock()
     push_docker_instance = push_docker.PushDocker(
-        [container_multiarch_push_item, operator_push_item_ok, container_source_push_item],
+        [
+            container_multiarch_push_item,
+            container_multiarch_push_item,
+            operator_push_item_ok,
+            container_source_push_item,
+        ],
         hub,
         "1",
         "some-target",


### PR DESCRIPTION
Container push items added from a multi-arch brew build have the
same push source and targets. Include only one of them as an item
for operations like signing, pushing, etc. so no duplicate content
are dealt with.

Refers to CLOUDDST-7152.