### PR TITLE
Remove sending UMB messages for tagging and untagging images

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -93,18 +93,7 @@ class ContainerImagePusher:
             docker_timeout=target_settings.get("docker_timeout"),
             docker_verify_tls=target_settings.get("docker_tls_verify") or False,
             docker_cert_path=target_settings.get("docker_cert_path") or None,
-            send_umb_msg=True,
-            umb_urls=target_settings["docker_settings"]["umb_urls"],
-            umb_cert=target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            # assumption that we'll continue using .pem format
-            umb_client_key=target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            umb_ca_cert=target_settings["docker_settings"].get(
-                "umb_ca_cert", "/etc/pki/tls/certs/ca-bundle.crt"
-            ),
+            send_umb_msg=False,
         )
 
     def copy_source_push_item(self, push_item):

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -617,18 +617,7 @@ class TagDocker:
             remove_last=remove_last,
             quay_user=target_settings["dest_quay_user"],
             quay_password=target_settings["dest_quay_password"],
-            send_umb_msg=True,
-            umb_urls=target_settings["docker_settings"]["umb_urls"],
-            umb_cert=target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            # assumption that we'll continue using .pem format
-            umb_client_key=target_settings["docker_settings"].get(
-                "umb_pub_cert", "/etc/pub/umb-pub-cert-key.pem"
-            ),
-            umb_ca_cert=target_settings["docker_settings"].get(
-                "umb_ca_cert", "/etc/pki/tls/certs/ca-bundle.crt"
-            ),
+            send_umb_msg=False,
         )
 
     def untag_image(self, push_item, tag):

--- a/tests/test_container_pusher.py
+++ b/tests/test_container_pusher.py
@@ -58,11 +58,7 @@ def test_tag_images(
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
-        send_umb_msg=True,
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        send_umb_msg=False,
     )
 
 
@@ -93,11 +89,7 @@ def test_copy_src_item(
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
-        send_umb_msg=True,
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        send_umb_msg=False,
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1222,11 +1222,7 @@ def test_clear_repo(
             pyxis_server="pyxis-server.com",
             pyxis_ssl_crtfile="/path/to/file.crt",
             pyxis_ssl_keyfile="/path/to/file.key",
-            send_umb_msg=True,
-            umb_urls=["url1.com", "url2.com"],
-            umb_cert="some/path.crt",
-            umb_client_key="some/path.key",
-            umb_ca_cert="cacert/path.crt",
+            send_umb_msg=False,
         )
 
 
@@ -1306,9 +1302,5 @@ def test_remove_repo(
             pyxis_server="pyxis-server.com",
             pyxis_ssl_crtfile="/path/to/file.crt",
             pyxis_ssl_keyfile="/path/to/file.key",
-            send_umb_msg=True,
-            umb_urls=["url1.com", "url2.com"],
-            umb_cert="some/path.crt",
-            umb_client_key="some/path.key",
-            umb_ca_cert="cacert/path.crt",
+            send_umb_msg=False,
         )

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -1868,11 +1868,7 @@ def test_run_untag_images_remove_last(mock_untag_images, target_settings):
         remove_last=True,
         quay_user="dest-quay-user",
         quay_password="dest-quay-pass",
-        send_umb_msg=True,
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        send_umb_msg=False,
     )
 
 
@@ -1888,11 +1884,7 @@ def test_run_untag_images_dont_remove_last(mock_untag_images, target_settings):
         remove_last=False,
         quay_user="dest-quay-user",
         quay_password="dest-quay-pass",
-        send_umb_msg=True,
-        umb_urls=["some-url1", "some-url2"],
-        umb_cert="/etc/pub/umb-pub-cert-key.pem",
-        umb_client_key="/etc/pub/umb-pub-cert-key.pem",
-        umb_ca_cert="/etc/pki/tls/certs/ca-bundle.crt",
+        send_umb_msg=False,
     )
 
 


### PR DESCRIPTION
These messages were initially intended for Metaxor, howerver,
it can extract all the necessary information from UMB messages
generated by pub. Thus, it's unnecessary to produce these
extra messages in pubtools-quay.