### PR TITLE
Allow disabling deprecation list functionality for IIB

### DIFF
--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -152,12 +152,15 @@ class OperatorPusher:
         """
         Get bundles to be deprecated in the index image.
 
+        If deprecation list URL isn't in the target settings, None is returned.
+
         Args:
             version: (str)
                 version for which deprecation list will be fetched.
 
         Returns:
-            list(str): list of bundles to be deprecated in the index image.
+            list(str)|None: list of bundles to be deprecated in the index image. or None if
+                            deprecation list URL was not specified.
         """
 
         def _get_requests_session():
@@ -174,6 +177,9 @@ class OperatorPusher:
             session.mount("https://", adapter)
 
             return session
+
+        if not self.target_settings["iib_deprecation_list_url"]:
+            return None
 
         deprecation_list = []
         deprecation_list_url = "{0}/{1}.yml/raw?ref=master".format(

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -138,6 +138,15 @@ def test_get_deprecation_list_invalid_data(target_settings, operator_push_item_o
             deprecation_list = pusher.get_deprecation_list("4.7")
 
 
+def test_get_deprecation_list_no_url(target_settings, operator_push_item_ok):
+    target_settings["iib_deprecation_list_url"] = None
+    pusher = operator_pusher.OperatorPusher([operator_push_item_ok], target_settings)
+
+    deprecation_list = pusher.get_deprecation_list("4.7")
+
+    assert deprecation_list == None
+
+
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
 def test_iib_add_bundles_str_deprecation_list(
     mock_run_entrypoint, target_settings, operator_push_item_ok


### PR DESCRIPTION
If deprecation list URL isn't present in the target settings,
bundle fetching is skipped and no to-be-deprecated bundles are
provided to IIB.