### PR TITLE
Fix the usage of overwrite from index target settings

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -47,19 +47,6 @@ def verify_target_settings(target_settings):
             raise InvalidTargetSettings(
                 "'{0}' must be present in the docker settings.".format(setting)
             )
-    if (
-        "iib_overwrite_from_index_token" in target_settings
-        and "iib_overwrite_from_index" not in target_settings
-    ) or (
-        "iib_overwrite_from_index_token" not in target_settings
-        and "iib_overwrite_from_index" in target_settings
-    ):
-        msg = (
-            "Either both or neither of 'iib_overwrite_from_index' and "
-            "'iib_overwrite_from_index_token' should be specified in target settings."
-        )
-        LOG.error(msg)
-        raise InvalidTargetSettings(msg)
 
 
 def task_iib_add_bundles(

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -230,7 +230,7 @@ class OperatorPusher:
         args += ["--iib-server", target_settings["iib_server"]]
         args += ["--iib-krb-principal", target_settings["iib_krb_principal"]]
 
-        if "iib_overwrite_from_index" in target_settings:
+        if target_settings.get("iib_overwrite_from_index", False):
             args += ["--overwrite-from-index"]
         if "iib_krb_ktfile" in target_settings:
             args += ["--iib-krb-ktfile", target_settings["iib_krb_ktfile"]]

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -105,19 +105,6 @@ class PushDocker:
                 raise InvalidTargetSettings(
                     "'{0}' must be present in the docker settings.".format(setting)
                 )
-        if (
-            "iib_overwrite_from_index_token" in self.target_settings
-            and "iib_overwrite_from_index" not in self.target_settings
-        ) or (
-            "iib_overwrite_from_index_token" not in self.target_settings
-            and "iib_overwrite_from_index" in self.target_settings
-        ):
-            msg = (
-                "Either both or neither of 'iib_overwrite_from_index' and "
-                "'iib_overwrite_from_index_token' should be specified in target settings."
-            )
-            LOG.error(msg)
-            raise InvalidTargetSettings(msg)
 
     @log_step("Get container push items")
     def get_docker_push_items(self):

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -27,12 +27,6 @@ def test_verify_target_settings_missing_docker_setting(target_settings):
         iib_operations.verify_target_settings(target_settings)
 
 
-def test_verify_target_settings_overwrite_index_mismatch(target_settings):
-    target_settings.pop("iib_overwrite_from_index_token")
-    with pytest.raises(exceptions.InvalidTargetSettings, match="Either both or neither.*"):
-        iib_operations.verify_target_settings(target_settings)
-
-
 @mock.patch("pubtools._quay.iib_operations.SignatureRemover")
 @mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -91,27 +91,6 @@ def test_init_verify_target_settings_missing_docker_item(
 
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
-def test_init_verify_target_settings_missing_overwrite_index(
-    mock_quay_api_client,
-    mock_quay_client,
-    target_settings,
-    container_multiarch_push_item,
-    operator_push_item_ok,
-):
-    hub = mock.MagicMock()
-    target_settings.pop("iib_overwrite_from_index", None)
-    with pytest.raises(exceptions.InvalidTargetSettings, match="Either both or neither of.*"):
-        push_docker_instance = push_docker.PushDocker(
-            [container_multiarch_push_item, operator_push_item_ok],
-            hub,
-            "1",
-            "some-target",
-            target_settings,
-        )
-
-
-@mock.patch("pubtools._quay.push_docker.QuayClient")
-@mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_get_container_push_items_ok(
     mock_quay_api_client,
     mock_quay_client,


### PR DESCRIPTION
Currently, there's no way to disable overwriting from index without
breaking IIB workflow. The reason is that overwrite from index is
enabled if the relevant option is present in target settings,
irregardless of the setting value. There's also a condition that either
both or neither overwrite_from_index and overwrite_from_index_token
must be present in target settings. This has an effect that if we want
to disable overwriting from index, we have to remove both settings
from the target. IIB uses the token for purposes other than overwriting
index image, namely authenticating with osbs stage when gathering index
image metadata.

This change makes it possible to set overwriting index image to False
without requiring to remove the token from target settings as well.