### PR TITLE
Add v2s2 formatting to skopeo copy operations

### DIFF
--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -104,9 +104,9 @@ class Executor(object):
                 Whether to copy all architectures (if multiarch image)
         """
         if all_arch:
-            cmd = "skopeo copy --all docker://{0} docker://{1}"
+            cmd = "skopeo copy --all docker://{0} docker://{1} --format v2s2"
         else:
-            cmd = "skopeo copy docker://{0} docker://{1}"
+            cmd = "skopeo copy docker://{0} docker://{1} --format v2s2"
 
         for dest_ref in dest_refs:
             LOG.info("Tagging source '{0}' to destination '{1}'".format(source_ref, dest_ref))

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -697,8 +697,12 @@ def test_skopeo_tag_images(mock_run_cmd):
 
     executor.tag_images("quay.io/repo/image:1", ["quay.io/repo/dest:1", "quay.io/repo/dest:2"])
     assert mock_run_cmd.call_args_list == [
-        mock.call("skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"),
-        mock.call("skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"),
+        mock.call(
+            "skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1 --format v2s2"
+        ),
+        mock.call(
+            "skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2 --format v2s2"
+        ),
     ]
 
 
@@ -710,8 +714,14 @@ def test_skopeo_tag_images_all_arch(mock_run_cmd):
         "quay.io/repo/image:1", ["quay.io/repo/dest:1", "quay.io/repo/dest:2"], True
     )
     assert mock_run_cmd.call_args_list == [
-        mock.call("skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"),
-        mock.call("skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"),
+        mock.call(
+            "skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"
+            " --format v2s2"
+        ),
+        mock.call(
+            "skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"
+            " --format v2s2"
+        ),
     ]
 
 


### PR DESCRIPTION
This argument will change the v2s1 manifests to v2s2 during migration
to Quay. For images that are already v2s2, it should have no effect.

Refers to CLOUDDST-5863