### PR TITLE
Add retries to image tagging as a part of pushes

### DIFF
--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -15,4 +15,7 @@ Set of utilities used in various parts of the code
 .. autofunction:: get_external_container_repo_name
 .. autofunction:: task_status
 .. autofunction:: log_step
-
+.. autofunction:: get_pyxis_ssl_paths
+.. autofunction:: timestamp
+.. autofunction:: run_with_retries
+.. autofunction:: retry

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -15,6 +15,7 @@ from pubtools.pluggy import pm
 LOG = logging.getLogger("pubtools.quay")
 
 INTERNAL_DELIMITER = "----"
+MAX_RETRY_WAIT = 120
 
 
 def setup_arg_parser(args):
@@ -323,3 +324,65 @@ def get_pyxis_ssl_paths(target_settings):
 def timestamp():
     """Return now() timestamp."""
     return str(time.time()).split(".")[0]
+
+
+def run_with_retries(function, message, tries=4, wait_time_increase=10):
+    """
+    Run the specified function until it succeeds or maximum retries are reached.
+
+    Wait time will increase after every retry, up to a point defined by MAX_RETRY_WAIT.
+
+    Args:
+        function (callable):
+            Function that should be retried. It must be able to run with 0 parameters.
+        message (str):
+            Message describing the action performed by the function. For example, "tag images".
+        tries (int):
+            Numbers of times to run the function before giving up.
+        wait_time_increase (int):
+            Time increase (in seconds) to wait before running the function again. Example (default):
+            RUN -> WAIT 0 -> RUN -> WAIT 10 -> RUN -> WAIT 20 -> RUN
+    """
+    wait_time = 0
+    for i in range(tries):
+        try:
+            result = function()
+            if i != 0:
+                LOG.info("%s succeeded [try: %s/%s]" % (message, i + 1, tries))
+            return result
+        except Exception as e:
+            if i < tries - 1:
+                wait_time = i * wait_time_increase if wait_time < MAX_RETRY_WAIT else MAX_RETRY_WAIT
+                LOG.warning(
+                    "%s failed. Will retry in %d seconds [try %s/%s]: %s"
+                    % (message, wait_time, i + 1, tries, str(e))
+                )
+                time.sleep(wait_time)
+                continue
+            LOG.error("%s repeatedly fails" % message)
+            raise
+
+
+def retry(message, tries=4, wait_time_increase=10):
+    """
+    Retry decorated function.
+
+    Args:
+        message (str):
+            Message describing the action performed by the function. For example, "tag images".
+        tries (int):
+            Numbers of times to run the function before giving up.
+        wait_time_increase (int):
+            Time increase (in seconds) to wait before running the function again. Example (default):
+            RUN -> WAIT 0 -> RUN -> WAIT 10 -> RUN -> WAIT 20 -> RUN
+    """
+
+    def inner_retry(func):
+        @functools.wraps(func)
+        def wrapper_func(*args, **kwargs):
+            bound = functools.partial(func, *args, **kwargs)
+            return run_with_retries(bound, message, tries, wait_time_increase)
+
+        return wrapper_func
+
+    return inner_retry


### PR DESCRIPTION
Transient errors of skopeo copy have been encountered during testing,
being likely caused by using containers to run skopeo. As
retrying a push has proven an effective solution to these issues,
an automatic retry mechanism was added when tag_images is run during
push workflows. Number of tries and wait time between them can be
changed by modifying target settings, so these values can be adjusted
based on observed behavior.

Retry decorator was implemented as well, as it may be utilized
in the future.

Refers to CLOUDDST-9847