### PR TITLE
Make IIB tag new index images with unique tag and use it to get manifest

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -105,11 +105,10 @@ def task_iib_add_bundles(
     )
     # Index image used to fetch manifest list. This image will never be overwritten
     iib_namespace = build_details.index_image_resolved.split("/")[1]
-    iib_repo = build_details.index_image_resolved.split("/")[2].split("@")[0]
     permanent_index_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=iib_namespace,
-        repo=iib_repo,
+        repo="iib",
         tag=build_details.build_tags[0],
     )
 
@@ -201,11 +200,10 @@ def task_iib_remove_operators(
 
     # Index image used to fetch manifest list. This image will never be overwritten
     iib_namespace = build_details.index_image_resolved.split("/")[1]
-    iib_repo = build_details.index_image_resolved.split("/")[2].split("@")[0]
     permanent_index_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=iib_namespace,
-        repo=iib_repo,
+        repo="iib",
         tag=build_details.build_tags[0],
     )
 
@@ -295,11 +293,10 @@ def task_iib_build_from_scratch(
 
     # Index image used to fetch manifest list. This image will never be overwritten
     iib_namespace = build_details.index_image_resolved.split("/")[1]
-    iib_repo = build_details.index_image_resolved.split("/")[2].split("@")[0]
     permanent_index_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
         namespace=iib_namespace,
-        repo=iib_repo,
+        repo="iib",
         tag=build_details.build_tags[0],
     )
     index_stamp = timestamp()

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -472,11 +472,10 @@ class PushDocker:
                 image_schema = "{host}/{namespace}/{repo}@{tag}"
                 # Index image used to fetch manifest list. This image will never be overwritten
                 iib_namespace = iib_result.index_image_resolved.split("/")[1]
-                iib_repo = iib_result.index_image_resolved.split("/")[2].split("@")[0]
                 permanent_index_image = image_schema.format(
                     host=self.target_settings.get("quay_host", "quay.io").rstrip("/"),
                     namespace=iib_namespace,
-                    repo=iib_repo,
+                    repo="iib",
                     tag=iib_result.build_tags[0],
                 )
                 ii_claim_messages += (

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -641,11 +641,10 @@ class OperatorSignatureHandler(SignatureHandler):
             signing_keys = iib_details["signing_keys"]
             # Index image used to fetch manifest list. This image will never be overwritten
             iib_namespace = iib_result.index_image_resolved.split("/")[1]
-            iib_repo = iib_result.index_image_resolved.split("/")[2].split("@")[0]
             permanent_index_image = image_schema.format(
                 host=self.target_settings.get("quay_host", "quay.io").rstrip("/"),
                 namespace=iib_namespace,
-                repo=iib_repo,
+                repo="iib",
                 tag=iib_result.build_tags[0],
             )
             # Version acts as a tag of the index image

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ docker
 pubtools>=0.3.0
 iiblib
 pubtools-iib
+pykerberos
 
 # -e git+https://code.engineering.redhat.com/gerrit/rhmsg#egg=rhmsg-0.9

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -47,6 +47,7 @@ def test_task_iib_add_bundles(
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["8-1"],
     )
     mock_iib_add_bundles.return_value = build_details
 
@@ -85,6 +86,7 @@ def test_task_iib_add_bundles(
         archs=["arch1", "arch2"],
         index_image="some-registry.com/redhat-namespace/new-index-image:5",
         deprecation_list=["bundle3", "bundle4"],
+        build_tags=["5-1"],
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
@@ -100,7 +102,7 @@ def test_task_iib_add_bundles(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["8", "8-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -138,6 +140,7 @@ def test_task_iib_remove_operators(
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["8-1"],
     )
     mock_iib_remove_operators.return_value = build_details
 
@@ -174,6 +177,7 @@ def test_task_iib_remove_operators(
         operators=["operator1", "operator2"],
         archs=["arch1", "arch2"],
         index_image="some-registry.com/redhat-namespace/new-index-image:5",
+        build_tags=["5-1"],
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
@@ -189,7 +193,7 @@ def test_task_iib_remove_operators(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["8", "8-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -224,6 +228,7 @@ def test_task_iib_build_from_scratch(
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["8-1"],
     )
     mock_iib_add_bundles.return_value = build_details
 
@@ -246,6 +251,7 @@ def test_task_iib_build_from_scratch(
     mock_iib_add_bundles.assert_called_once_with(
         bundles=["bundle1", "bundle2"],
         archs=["arch1", "arch2"],
+        build_tags=["12-1"],
         target_settings=target_settings,
     )
     mock_run_tag_images.assert_called_once_with(
@@ -261,7 +267,7 @@ def test_task_iib_build_from_scratch(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/iib@sha256:a1a1a1", ["12", "12-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["12", "12-timestamp"]
     )
 
 

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -102,7 +102,7 @@ def test_task_iib_add_bundles(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["8", "8-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -193,7 +193,7 @@ def test_task_iib_remove_operators(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["8", "8-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["8", "8-timestamp"]
     )
 
     mock_signature_remover.assert_called_once_with(
@@ -267,7 +267,7 @@ def test_task_iib_build_from_scratch(
         mock_hub, "1", target_settings, "some-target"
     )
     mock_sign_task_index_image.assert_called_once_with(
-        ["some-key"], "quay.io/iib-namespace/new-index-image:8-1", ["12", "12-timestamp"]
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["12", "12-timestamp"]
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -130,11 +130,13 @@ def test_push_docker_multiarch_merge_ml_operator(
         IIBRes(
             "registry.com/namespace/index-image@sha256:v4.5",
             "registry.com/namespace/index-image@sha256:a1a1a1",
+            ["v4.5-1"],
         ),
         # pubtools-iib-add-bundles (4.6)
         IIBRes(
             "registry.com/namespace/index-image@sha256:v4.6",
             "registry.com/namespace/index-image@sha256:b2b2b2",
+            ["v4.6-1"],
         ),
     ]
 
@@ -208,12 +210,12 @@ def test_push_docker_multiarch_merge_ml_operator(
         m.get("https://git-server.com/v4_5.yml/raw?ref=master")
         m.get("https://git-server.com/v4_6.yml/raw?ref=master")
         m.get(
-            "https://quay.io/v2/namespace/iib/manifests/sha256:a1a1a1",
+            "https://quay.io/v2/namespace/index-image/manifests/v4.5-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
         m.get(
-            "https://quay.io/v2/namespace/iib/manifests/sha256:b2b2b2",
+            "https://quay.io/v2/namespace/index-image/manifests/v4.6-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1028,15 +1030,11 @@ def test_task_iib_add_bundles(
     src_manifest_list,
     fake_cert_key_paths,
 ):
-    class IIBRes:
-        def __init__(self, index_image, index_image_resolved):
-            self.index_image = index_image
-            self.index_image_resolved = index_image_resolved
-
     mock_timestamp.return_value = "timestamp"
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["8-1"],
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
     mock_run_cmd.side_effect = [("Login Succeeded", "err"), ("Login Succeeded", "err")]
@@ -1064,7 +1062,7 @@ def test_task_iib_add_bundles(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            "https://quay.io/v2/iib-namespace/new-index-image/manifests/8-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1109,6 +1107,7 @@ def test_task_iib_remove_operators(
     build_details = IIBRes(
         "some-registry.com/iib-namespace/new-index-image:8",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["8-1"],
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
     mock_run_cmd.return_value = ("Login Succeeded", "err")
@@ -1136,7 +1135,7 @@ def test_task_iib_remove_operators(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            "https://quay.io/v2/iib-namespace/new-index-image/manifests/8-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1177,8 +1176,9 @@ def test_task_iib_build_from_scratch(
     fake_cert_key_paths,
 ):
     build_details = IIBRes(
-        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/new-index-image:12",
         "some-registry.com/iib-namespace/new-index-image@sha256:a1a1a1",
+        ["12-1"],
     )
     mock_run_entrypoint_operator_pusher.return_value = build_details
     mock_run_cmd.return_value = ("Login Succeeded", "err")
@@ -1189,7 +1189,7 @@ def test_task_iib_build_from_scratch(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/iib/manifests/sha256:a1a1a1",
+            "https://quay.io/v2/iib-namespace/new-index-image/manifests/12-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -210,12 +210,12 @@ def test_push_docker_multiarch_merge_ml_operator(
         m.get("https://git-server.com/v4_5.yml/raw?ref=master")
         m.get("https://git-server.com/v4_6.yml/raw?ref=master")
         m.get(
-            "https://quay.io/v2/namespace/index-image/manifests/v4.5-1",
+            "https://quay.io/v2/namespace/iib/manifests/v4.5-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
         m.get(
-            "https://quay.io/v2/namespace/index-image/manifests/v4.6-1",
+            "https://quay.io/v2/namespace/iib/manifests/v4.6-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1062,7 +1062,7 @@ def test_task_iib_add_bundles(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/new-index-image/manifests/8-1",
+            "https://quay.io/v2/iib-namespace/iib/manifests/8-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1135,7 +1135,7 @@ def test_task_iib_remove_operators(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/new-index-image/manifests/8-1",
+            "https://quay.io/v2/iib-namespace/iib/manifests/8-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )
@@ -1189,7 +1189,7 @@ def test_task_iib_build_from_scratch(
 
     with requests_mock.Mocker() as m:
         m.get(
-            "https://quay.io/v2/iib-namespace/new-index-image/manifests/12-1",
+            "https://quay.io/v2/iib-namespace/iib/manifests/12-1",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
         )

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -1077,7 +1077,7 @@ def test_push_docker_full_success(
     assert mock_sign_container_images.call_args_list[1] == mock.call(
         [container_multiarch_push_item], only_v2s1_manifests=True
     )
-    mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
+    mock_operator_pusher.assert_called_once_with([operator_push_item_ok], "1", target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with(
         {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
@@ -1203,7 +1203,7 @@ def test_push_docker_full_success_repush(
         [container_multiarch_push_item, container_push_item_external_repos],
         only_v2s1_manifests=True,
     )
-    mock_operator_pusher.assert_called_once_with([operator_push_item_ok], target_settings)
+    mock_operator_pusher.assert_called_once_with([operator_push_item_ok], "1", target_settings)
     mock_build_index_images.assert_called_once_with()
     mock_push_index_images.assert_called_once_with(
         {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -988,7 +988,7 @@ def test_sign_operator_images_no_signatures(
     )
     sig_handler.sign_operator_images(iib_results, "stamp")
     mock_construct_index_claim_msgs.assert_called_once_with(
-        "quay.io/iib-namespace/image:v4.5-1", ["v4.5", "v4.5-stamp"], [None]
+        "quay.io/iib-namespace/iib:v4.5-1", ["v4.5", "v4.5-stamp"], [None]
     )
     mock_get_radas_signatures.assert_not_called()
     mock_validate_radas_msgs.assert_not_called()

--- a/tests/utils/misc.py
+++ b/tests/utils/misc.py
@@ -105,6 +105,7 @@ def mock_entry_point(dist, group, name):
 
 
 class IIBRes:
-    def __init__(self, index_image, index_image_resolved):
+    def __init__(self, index_image, index_image_resolved, build_tags):
         self.index_image = index_image
         self.index_image_resolved = index_image_resolved
+        self.build_tags = build_tags


### PR DESCRIPTION
A while ago it was discovered that using floating tag of index images
to get manifest list may return the incorrect result due to a race
condition (index image was overwritten by a parallel push). The solution
was to use intermediate index image specified by digest. However, as
this index image may be overwritten as well, the new solution is to
make IIB tag the new index image with a unique tag and use it to
get the manifest list for signing. Tag uniqueness is ensured by
combining the index image floating tag (OCP version) and pub task
ID. This change was applied to all IIB calls done by pubtools-quay,
so standard push-docker workflow and separate IIB-only workflows.

Few minor unrelated changes were done as well, namely cleanup of
unused variables, docstring fixes, and change of "failed" variable
in push_docker.py to bool instead of integer because this isn't C.

Refers to CLOUDDST-6236