### PR TITLE
Skip checking for repo deprecation based on value in target settings

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -254,8 +254,9 @@ class PushDocker:
                     raise
 
             # Check if repo is not deprecated
-            # TODO: check with Comet team if this is a reliable way of checking
-            if "Deprecated" in metadata["release_categories"]:
+            if "Deprecated" in metadata["release_categories"] and target_settings.get(
+                "do_repo_deprecation_check", True
+            ):
                 raise InvalidRepository("Repository {0} is deprecated".format(repo))
 
             # if we're pushing to prod target, check if repo exists on stage as well

--- a/tests/test_container_pusher.py
+++ b/tests/test_container_pusher.py
@@ -96,6 +96,8 @@ def test_tag_images_retry(
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
+        registry_username="quay-executor-user",
+        registry_password="quay-executor-password",
         send_umb_msg=False,
     )
 


### PR DESCRIPTION
Until the relevant epic is completed, deprecation flag in repo
metadata should not be considered a source of truth for whether a
repo is actually deprecated. Thus, raising an error in the presence
of this flag can now be disabled in the target settings.