### PR TITLE
Sign V2S1 manifests

### DIFF
--- a/docs/source/signature_handler.rst
+++ b/docs/source/signature_handler.rst
@@ -21,6 +21,7 @@ Classes which handle container image signing. Base class, "SignatureHandler" con
 .. autoclass:: ContainerSignatureHandler
 
    .. automethod:: construct_item_claim_messages
+   .. automethod:: construct_item_schema1_claim_messages
    .. automethod:: construct_variant_claim_messages
    .. automethod:: sign_container_images
 

--- a/pubtools/_quay/quay_client.py
+++ b/pubtools/_quay/quay_client.py
@@ -78,7 +78,11 @@ class QuayClient:
             kwargs = {"headers": {"Accept": QuayClient.MANIFEST_V2S1_TYPE}}
             response = self._request_quay("GET", endpoint, kwargs)
 
-            if response.headers["Content-Type"] != QuayClient.MANIFEST_V2S1_TYPE:
+            # text/plain may be returned for V2S1 by our CDN
+            if (
+                response.headers["Content-Type"] != QuayClient.MANIFEST_V2S1_TYPE
+                and "text/plain" not in response.headers["Content-Type"]
+            ):
                 raise ManifestTypeError("Image {0} doesn't have a V2S1 manifest".format(image))
 
             if raw:

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -8,7 +8,12 @@ import tempfile
 import proton
 
 from .exceptions import SigningError
-from .utils.misc import run_entrypoint, log_step, get_pyxis_ssl_paths
+from .utils.misc import (
+    run_entrypoint,
+    log_step,
+    get_pyxis_ssl_paths,
+    get_internal_container_repo_name,
+)
 from .quay_client import QuayClient
 from .manifest_claims_handler import ManifestClaimsHandler
 
@@ -49,6 +54,7 @@ class SignatureHandler:
 
         self.quay_host = self.target_settings.get("quay_host", "quay.io").rstrip("/")
         self._src_quay_client = None
+        self._dest_quay_client = None
 
     @property
     def src_quay_client(self):
@@ -60,6 +66,17 @@ class SignatureHandler:
                 self.quay_host,
             )
         return self._src_quay_client
+
+    @property
+    def dest_quay_client(self):
+        """Create and access QuayClient for dest image."""
+        if self._dest_quay_client is None:
+            self._dest_quay_client = QuayClient(
+                self.target_settings["dest_quay_user"],
+                self.target_settings["dest_quay_password"],
+                self.quay_host,
+            )
+        return self._dest_quay_client
 
     @classmethod
     def create_manifest_claim_message(
@@ -427,6 +444,44 @@ class ContainerSignatureHandler(SignatureHandler):
 
         return claim_messages
 
+    def construct_item_schema1_claim_messages(self, push_item):
+        """
+        Construct all the schema1 signature claim messages for RADAS for one push item.
+
+        The reason why these claims are created separately at a different stage is that
+        an image must already be in its destination in order to retrieve its schema1 manifest.
+        Thus, there will be a small time window where unsigned schema1 digests will be available
+        for customers.
+
+        NOTE: Only one schema1 manifest exists for every tag. This is true even for multiarch
+        images. The reason is that schema1 manifests predate the existence of manifest lists.
+
+        push_item (ContainerPushItem):
+            Container push item whose schema1 claim messages will be created.
+        Returns ([dict]):
+            Schema1 claim messages for a given push item.
+        """
+        LOG.info("Constructing schema1 claim messages for push item '{0}'".format(push_item))
+        claim_messages = []
+        image_schema = "{host}/{namespace}/{repo}:{tag}"
+
+        if push_item.claims_signing_key:
+            for repo, tags in sorted(push_item.metadata["tags"].items()):
+                internal_repo = get_internal_container_repo_name(repo)
+                for tag in tags:
+                    dest_ref = image_schema.format(
+                        host=self.quay_host,
+                        namespace=self.target_settings["quay_namespace"],
+                        repo=internal_repo,
+                        tag=tag,
+                    )
+                    digest = self.dest_quay_client.get_manifest_digest(dest_ref, v2s1_manifest=True)
+                    claim_messages += self.construct_variant_claim_messages(
+                        repo, tag, digest, [push_item.claims_signing_key]
+                    )
+
+        return claim_messages
+
     def construct_variant_claim_messages(self, repo, tag, digest, signing_keys):
         """
         Construct claim messages for all specified variations of a given image.
@@ -466,7 +521,7 @@ class ContainerSignatureHandler(SignatureHandler):
         return claim_messages
 
     @log_step("Sign container images")
-    def sign_container_images(self, push_items):
+    def sign_container_images(self, push_items, only_v2s1_manifests=False):
         """
         Perform all the steps needed to sign the images of specified push items.
 
@@ -476,9 +531,16 @@ class ContainerSignatureHandler(SignatureHandler):
         - send messages to RADAS and receive signatures (ManifestClaimsHandler class)
         - Upload new signatures to Pyxis
 
+        NOTE: The reason for separating the creation of schema1 and schema2 claim messages is that
+        they must happen in different stages of the push, schema2 before pushing to destination,
+        and schema1 after pushing to destination.
+
         Args:
             push_items (([ContainerPushItem])):
                 Container push items whose images will be signed.
+            only_v2s1_manifests (bool):
+                If True, only claim messages for schema1 manifests are created. If False,
+                only claim messages for schema2 manifests are created.
         """
         if not self.target_settings["docker_settings"].get(
             "docker_container_signing_enabled", False
@@ -488,7 +550,10 @@ class ContainerSignatureHandler(SignatureHandler):
 
         claim_messages = []
         for item in push_items:
-            claim_messages += self.construct_item_claim_messages(item)
+            if only_v2s1_manifests:
+                claim_messages += self.construct_item_schema1_claim_messages(item)
+            else:
+                claim_messages += self.construct_item_claim_messages(item)
         claim_messages = self.remove_duplicate_claim_messages(claim_messages)
         claim_messages = self.filter_claim_messages(claim_messages)
         if not claim_messages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1369,6 +1369,24 @@ def dest_manifest_list():
 
 
 @pytest.fixture
+def v2s1_manifest():
+    return {
+        "schemaVersion": 1,
+        "tag": "5",
+        "name": "some-repo/some-image",
+        "architecture": "amd64",
+        "fsLayers": [
+            {"blobSum": "sha256:e6307d6a11e152dd13522c8fc4209bf859b3d2d0acbdd2aaaddf314cdd3677d8"}
+        ],
+        "history": [
+            {
+                "v1Compatibility": '{"comment": "Created by Image Factory", "created": "2020-11-20T16:43:05Z", "config": {"Systemd": false, "Hostname": "", "Entrypoint": null, "Env": ["DISTTAG=f34container", "FGC=f34", "container=oci"], "OnBuild": null, "OpenStdin": false, "MacAddress": "", "User": "", "VolumeDriver": "", "AttachStderr": false, "AttachStdout": false, "NetworkDisabled": false, "StdinOnce": false, "Cmd": ["/bin/bash"], "WorkingDir": "", "AttachStdin": false, "Volumes": null, "Tty": false, "Domainname": "", "Image": "", "Labels": {"version": "34", "vendor": "Fedora Project", "name": "fedora", "license": "MIT"}, "ExposedPorts": null}, "container_config": {"Systemd": false, "Hostname": "", "Entrypoint": null, "Env": null, "OnBuild": null, "OpenStdin": false, "MacAddress": "", "User": "", "VolumeDriver": "", "AttachStderr": false, "AttachStdout": false, "NetworkDisabled": false, "StdinOnce": false, "Cmd": null, "WorkingDir": "", "AttachStdin": false, "Volumes": null, "Tty": false, "Domainname": "", "Image": "", "Labels": null, "ExposedPorts": null}, "Size": 69754778, "architecture": "amd64", "docker_version": "1.10.1", "os": "linux", "id": "1a1d7fd200d783bd61e78e9e2fed23c8c1ffcefe54168939c53084f4af7e884e"}'
+            }
+        ],
+    }
+
+
+@pytest.fixture
 def tag_docker_push_item_add_integration():
     return MockContainerPushItem(
         file_path="push_item_filepath",

--- a/tests/test_data/test_expected_schema1_claim_messages.json
+++ b/tests/test_data/test_expected_schema1_claim_messages.json
@@ -1,0 +1,68 @@
+[
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "0",
+        "manifest_digest": "sha256:a1a1a1a1",
+        "repo": "target/repo1",
+        "image_name": "target/repo1",
+        "docker_reference": "some-registry1.com/target/repo1:tag1",
+        "created": "2021-03-19T14:45:23.128632Z"
+    },
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "1",
+        "manifest_digest": "sha256:a1a1a1a1",
+        "repo": "target/repo1",
+        "image_name": "target/repo1",
+        "docker_reference": "some-registry2.com/target/repo1:tag1",
+        "created": "2021-03-19T14:45:23.128632Z"
+    },
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "2",
+        "manifest_digest": "sha256:b2b2b2b2",
+        "repo": "target/repo1",
+        "image_name": "target/repo1",
+        "docker_reference": "some-registry1.com/target/repo1:tag2",
+        "created": "2021-03-19T14:45:23.128632Z"
+    },
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "3",
+        "manifest_digest": "sha256:b2b2b2b2",
+        "repo": "target/repo1",
+        "image_name": "target/repo1",
+        "docker_reference": "some-registry2.com/target/repo1:tag2",
+        "created": "2021-03-19T14:45:23.128632Z"
+    },
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "4",
+        "manifest_digest": "sha256:c3c3c3c3",
+        "repo": "target/repo2",
+        "image_name": "target/repo2",
+        "docker_reference": "some-registry1.com/target/repo2:tag3",
+        "created": "2021-03-19T14:45:23.128632Z"
+    },
+    {
+        "sig_key_id": "some-key",
+        "claim_file": "some-encode",
+        "pub_task_id": "1",
+        "request_id": "5",
+        "manifest_digest": "sha256:c3c3c3c3",
+        "repo": "target/repo2",
+        "image_name": "target/repo2",
+        "docker_reference": "some-registry2.com/target/repo2:tag3",
+        "created": "2021-03-19T14:45:23.128632Z"
+    }
+]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -39,6 +39,7 @@ def test_push_docker_multiarch_merge_ml_operator(
     operator_push_item_ok,
     src_manifest_list,
     dest_manifest_list,
+    v2s1_manifest,
     fake_cert_key_paths,
 ):
     # hub usage has to be mocked
@@ -68,6 +69,16 @@ def test_push_docker_multiarch_merge_ml_operator(
             }
         ],
         # pubtools-pyxis-upload-signatures
+        [],
+        # pubtools-pyxis-get-signatures (containers) (v2s1)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures (v2s1)
         [],
         # pubtools-pyxis-get-signatures (operators)
         [
@@ -170,6 +181,13 @@ def test_push_docker_multiarch_merge_ml_operator(
                     },
                 },
             ],
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.list.v2+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            text=json.dumps(v2s1_manifest, sort_keys=True),
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v1+json"},
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.v1+json"},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:9daac465523ce42a89e605151734e7b92c5ade2123055a6a2aeabbf60e5edfa4",
@@ -233,6 +251,7 @@ def test_push_docker_multiarch_simple_workflow(
     target_settings,
     container_multiarch_push_item_integration,
     src_manifest_list,
+    v2s1_manifest,
     fake_cert_key_paths,
 ):
     # hub usage has to be mocked
@@ -262,6 +281,16 @@ def test_push_docker_multiarch_simple_workflow(
             }
         ],
         # pubtools-pyxis-upload-signatures
+        [],
+        # pubtools-pyxis-get-signatures (containers) (v2s1)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures (v2s1)
         [],
         # pubtools-pyxis-get-signatures (containers) (removing signatures)
         [
@@ -325,6 +354,12 @@ def test_push_docker_multiarch_simple_workflow(
                     },
                 },
             ],
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            text=json.dumps(v2s1_manifest, sort_keys=True),
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v1+json"},
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.v1+json"},
         )
         m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:8ce181d89b7bb7f1639d8df3d65d630b1322d0bb6daff5c492eec24ec53628d5",
@@ -366,6 +401,7 @@ def test_push_docker_source(
     target_settings,
     container_source_push_item_integration,
     src_manifest_list,
+    v2s1_manifest,
     fake_cert_key_paths,
 ):
     # hub usage has to be mocked
@@ -395,6 +431,16 @@ def test_push_docker_source(
             }
         ],
         # pubtools-pyxis-upload-signatures
+        [],
+        # pubtools-pyxis-get-signatures (containers) (v2s1)
+        [
+            {
+                "reference": "registry.com/namespace/repo:1",
+                "manifest_digest": "e5e5e5",
+                "sig_key_id": "some-key",
+            }
+        ],
+        # pubtools-pyxis-upload-signatures (v2s1)
         [],
         # pubtools-pyxis-get-signatures (containers) (removing signatures)
         [
@@ -460,6 +506,18 @@ def test_push_docker_source(
             ],
         )
         m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/1.0",
+            text=json.dumps(v2s1_manifest, sort_keys=True),
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v1+json"},
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.v1+json"},
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            text=json.dumps(v2s1_manifest, sort_keys=True),
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v1+json"},
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.v1+json"},
+        )
+        m.get(
             "https://quay.io/v2/some-namespace/target----repo/manifests/sha256:8ce181d89b7bb7f1639d8df3d65d630b1322d0bb6daff5c492eec24ec53628d5",
             json=src_manifest_list,
             headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"},
@@ -497,6 +555,7 @@ def test_push_docker_multiarch_rollback(
     target_settings,
     container_multiarch_push_item_integration,
     src_manifest_list,
+    v2s1_manifest,
     fake_cert_key_paths,
 ):
     # hub usage has to be mocked
@@ -570,6 +629,12 @@ def test_push_docker_multiarch_rollback(
                     },
                 },
             ],
+        )
+        m.get(
+            "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",
+            text=json.dumps(v2s1_manifest, sort_keys=True),
+            headers={"Content-Type": "application/vnd.docker.distribution.manifest.v1+json"},
+            request_headers={"Accept": "application/vnd.docker.distribution.manifest.v1+json"},
         )
         m.put(
             "https://quay.io/v2/some-namespace/target----repo/manifests/latest-test-tag",


### PR DESCRIPTION
Since Quay.io generates V2S1 manifest for an image on demand,
signatures for digests of these manifests have to be created
as well. As the manifest values depend on the destination
location, the V2S1 manifests can only be queried after the
images are pushed. For this reason, signing of V2S1 digests
is done separately, after the image push. An unfortunate
side effect is that there will be a small time window where
a customer may pull a newly pushed image whose signature has
not been generated yet.

Multiarch images are not relevant for V2S1 because it predates
the existence of a manifest list. If the signing of V2S1 digests
fails, some newly pushed content may be left unsigned
indefinitely. I decided against implementing a rollback
functionality, since even rollback is only best-effort, and in
case of its failure nothing else guarantees the validity
of pushed data. If a push fails, the issues should be
resolved by a retried push.

The logic to remove no longer used signatures was extended for
V2S1 digests. In case of overwriting an existing tag, its
schema1 signatures will be removed as well.

A few unrelated things were fixed in this commit:
- "operator_push_items" parameter was removed from
  "remove_old_signatures" method because it wasn't used
  anywhere
- "esig" variable in "remove_old_signatures" was renamed
  to "existing_signature"
- "failed" variable in "run" is now a boolean instead of
  using 0/1 for True/False

Refers to CLOUDDST-11173