### PR TITLE
Tag index image timestamps with permanent index image as a source

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -142,7 +142,10 @@ def task_iib_add_bundles(
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image, dest_image_stamp], True, target_settings
+        build_details.index_image, [dest_image], True, target_settings
+    )
+    ContainerImagePusher.run_tag_images(
+        permanent_index_image, [dest_image_stamp], True, target_settings
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -237,7 +240,10 @@ def task_iib_remove_operators(
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image, dest_image_stamp], True, target_settings
+        build_details.index_image, [dest_image], True, target_settings
+    )
+    ContainerImagePusher.run_tag_images(
+        permanent_index_image, [dest_image_stamp], True, target_settings
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -317,7 +323,10 @@ def task_iib_build_from_scratch(
 
     # Push image to Quay
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image, dest_image_stamp], True, target_settings
+        build_details.index_image, [dest_image], True, target_settings
+    )
+    ContainerImagePusher.run_tag_images(
+        permanent_index_image, [dest_image_stamp], True, target_settings
     )
 
 

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -144,8 +144,16 @@ def task_iib_add_bundles(
     ContainerImagePusher.run_tag_images(
         build_details.index_image, [dest_image], True, target_settings
     )
+    # Permanent index image with proxy as a host must be used because skopeo cannot handle
+    # login to two Quay namespaces at the same time
+    permanent_index_image_proxy = image_schema_tag.format(
+        host=build_details.index_image.split("/")[0],
+        namespace=iib_namespace,
+        repo="iib",
+        tag=build_details.build_tags[0],
+    )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -242,8 +250,16 @@ def task_iib_remove_operators(
     ContainerImagePusher.run_tag_images(
         build_details.index_image, [dest_image], True, target_settings
     )
+    # Permanent index image with proxy as a host must be used because skopeo cannot handle
+    # login to two Quay namespaces at the same time
+    permanent_index_image_proxy = image_schema_tag.format(
+        host=build_details.index_image.split("/")[0],
+        namespace=iib_namespace,
+        repo="iib",
+        tag=build_details.build_tags[0],
+    )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -325,8 +341,16 @@ def task_iib_build_from_scratch(
     ContainerImagePusher.run_tag_images(
         build_details.index_image, [dest_image], True, target_settings
     )
+    # Permanent index image with proxy as a host must be used because skopeo cannot handle
+    # login to two Quay namespaces at the same time
+    permanent_index_image_proxy = image_schema_tag.format(
+        host=build_details.index_image.split("/")[0],
+        namespace=iib_namespace,
+        repo="iib",
+        tag=build_details.build_tags[0],
+    )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
     )
 
 

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -470,7 +470,7 @@ class OperatorPusher:
 
             _, tag = build_details.index_image.split(":", 1)
             permanent_index_image = image_schema_tag.format(
-                host=self.quay_host,
+                host=build_details.index_image_resolved.split("/")[0],
                 namespace=build_details.index_image_resolved.split("/")[1],
                 repo="iib",
                 tag=build_details.build_tags[0],

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -89,15 +89,24 @@ def test_task_iib_add_bundles(
         build_tags=["5-1"],
         target_settings=target_settings,
     )
-    mock_run_tag_images.assert_called_once_with(
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
         "some-registry.com/iib-namespace/new-index-image:8",
         [
             "quay.io/some-namespace/operators----index-image:8",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "quay.io/iib-namespace/iib:8-1",
+        [
             "quay.io/some-namespace/operators----index-image:8-timestamp",
         ],
         True,
         target_settings,
     )
+
     mock_operator_signature_handler.assert_called_once_with(
         mock_hub, "1", target_settings, "some-target"
     )
@@ -180,10 +189,18 @@ def test_task_iib_remove_operators(
         build_tags=["5-1"],
         target_settings=target_settings,
     )
-    mock_run_tag_images.assert_called_once_with(
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
         "some-registry.com/iib-namespace/new-index-image:8",
         [
             "quay.io/some-namespace/operators----index-image:8",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "quay.io/iib-namespace/iib:8-1",
+        [
             "quay.io/some-namespace/operators----index-image:8-timestamp",
         ],
         True,
@@ -254,10 +271,18 @@ def test_task_iib_build_from_scratch(
         build_tags=["12-1"],
         target_settings=target_settings,
     )
-    mock_run_tag_images.assert_called_once_with(
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
         "some-registry.com/iib-namespace/new-index-image:8",
         [
             "quay.io/some-namespace/operators----index-image:12",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "quay.io/iib-namespace/iib:8-1",
+        [
             "quay.io/some-namespace/operators----index-image:12-timestamp",
         ],
         True,

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -99,7 +99,7 @@ def test_task_iib_add_bundles(
         target_settings,
     )
     assert mock_run_tag_images.call_args_list[1] == mock.call(
-        "quay.io/iib-namespace/iib:8-1",
+        "some-registry.com/iib-namespace/iib:8-1",
         [
             "quay.io/some-namespace/operators----index-image:8-timestamp",
         ],
@@ -199,7 +199,7 @@ def test_task_iib_remove_operators(
         target_settings,
     )
     assert mock_run_tag_images.call_args_list[1] == mock.call(
-        "quay.io/iib-namespace/iib:8-1",
+        "some-registry.com/iib-namespace/iib:8-1",
         [
             "quay.io/some-namespace/operators----index-image:8-timestamp",
         ],
@@ -281,7 +281,7 @@ def test_task_iib_build_from_scratch(
         target_settings,
     )
     assert mock_run_tag_images.call_args_list[1] == mock.call(
-        "quay.io/iib-namespace/iib:8-1",
+        "some-registry.com/iib-namespace/iib:8-1",
         [
             "quay.io/some-namespace/operators----index-image:12-timestamp",
         ],


### PR DESCRIPTION
Two changes are made:
- For the IIB operation workflows, create a separate tagging
  operation for timestamp tags. Not including this when timestamp
  tags were introduced is an oversight, as using production tag
  as a source may reference an incorrect image (image pushed during
  separate task running in parallel). On the other hand, using
  permanent index image is safe and will ensure that every built
  image will always be available through a timestamp tag
- In the Push Docker workflow, this fact was originally accounted
  for, which is why it uses a digest to reference a source. However,
  since permanent index image is now available, it should be used
  as a source instead.

Refers to CLOUDDST-6236