### PR TITLE
Add a timeout to all HTTP requests

### DIFF
--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -193,7 +193,7 @@ class OperatorPusher:
 
         LOG.info("Getting the deprecation list for OCP version {0}".format(version))
         session = _get_requests_session()
-        response = session.get(url=deprecation_list_url)
+        response = session.get(url=deprecation_list_url, timeout=10)
         if not response.ok:
             LOG.error(
                 "Could not retrieve deprecation list after multiple attempts."

--- a/pubtools/_quay/quay_client.py
+++ b/pubtools/_quay/quay_client.py
@@ -266,7 +266,7 @@ class QuayClient:
         session.mount("https://", adapter)
         # Make an authentication request to the specified realm with the provided REST parameters.
         # Basic username + password authentication is expected.
-        r = session.get(host, params=params, auth=(self.username, self.password))
+        r = session.get(host, params=params, auth=(self.username, self.password), timeout=10)
         r.raise_for_status()
 
         if "token" not in r.json():

--- a/pubtools/_quay/quay_session.py
+++ b/pubtools/_quay/quay_session.py
@@ -55,6 +55,8 @@ class QuaySession(object):
         Returns:
             requests.Response: A response object.
         """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 10
         return self.session.get(self._api_url(endpoint), **kwargs)
 
     def post(self, endpoint, **kwargs):
@@ -69,6 +71,8 @@ class QuaySession(object):
         Returns:
             requests.Response: A response object.
         """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 10
         return self.session.post(self._api_url(endpoint), **kwargs)
 
     def put(self, endpoint, **kwargs):
@@ -83,6 +87,8 @@ class QuaySession(object):
         Returns:
             requests.Response: A response object.
         """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 10
         return self.session.put(self._api_url(endpoint), **kwargs)
 
     def delete(self, endpoint, **kwargs):
@@ -97,6 +103,8 @@ class QuaySession(object):
         Returns:
             requests.Response: A response object.
         """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 10
         return self.session.delete(self._api_url(endpoint), **kwargs)
 
     def request(self, method, endpoint, **kwargs):
@@ -113,6 +121,8 @@ class QuaySession(object):
         Returns:
             requests.Response: A response object.
         """
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = 10
         return self.session.request(method, self._api_url(endpoint), **kwargs)
 
     def _api_url(self, endpoint):

--- a/tests/test_quay_client.py
+++ b/tests/test_quay_client.py
@@ -94,6 +94,7 @@ def test_authenticate_quay_success(mock_session, mock_quay_session):
         "https://quay.io/v2/auth",
         auth=("user", "pass"),
         params={"service": "quay.io", "scope": "repository:namespace/some-repo:pull"},
+        timeout=10,
     )
     mocked_quay_session.set_auth_token.assert_called_once_with("abcdef")
 

--- a/tests/test_quay_session.py
+++ b/tests/test_quay_session.py
@@ -71,6 +71,7 @@ def test_get(mock_session):
 
     kwargs = {"headers": {"Accept": "application/json"}}
     session.get("get/data/1", **kwargs)
+    kwargs["timeout"] = 10
     mocked_session.get.assert_called_with("https://quay.io/v2/get/data/1", **kwargs)
 
 
@@ -83,6 +84,7 @@ def test_post(mock_session):
 
     kwargs = {"headers": {"Accept": "application/json"}, "data": "some data"}
     session.post("post/data/2", **kwargs)
+    kwargs["timeout"] = 10
     mocked_session.post.assert_called_with("https://quay.io/v2/post/data/2", **kwargs)
 
 
@@ -95,6 +97,7 @@ def test_put(mock_session):
 
     kwargs = {"data": "new data"}
     session.put("put/data/3", **kwargs)
+    kwargs["timeout"] = 10
     mocked_session.put.assert_called_with("https://quay.io/v2/put/data/3", **kwargs)
 
 
@@ -107,6 +110,7 @@ def test_delete(mock_session):
 
     kwargs = {"data": "old data"}
     session.delete("delete/data/4", **kwargs)
+    kwargs["timeout"] = 10
     mocked_session.delete.assert_called_with("https://quay.io/v2/delete/data/4", **kwargs)
 
 
@@ -119,4 +123,5 @@ def test_request(mock_session):
 
     kwargs = {"headers": {"Accept": "application/json"}, "data": "some data"}
     session.request("POST", "post/data/2", **kwargs)
+    kwargs["timeout"] = 10
     mocked_session.request.assert_called_with("POST", "https://quay.io/v2/post/data/2", **kwargs)


### PR DESCRIPTION
It was recently observed that queries to Quay may hang indefinitely
if no data is received. Add a timeout parameter to all requests
queries so that this type of issue is prevented in the future.
This parameter should work on requests version 2.6.0 which we use
in production.

A bit more info:
I determined the root cause from the logs of this push: https://10.0.149.4/pub/task/11068/log/stdout.log
The error happened after the log message "Constructing claim messages for push item..." but before the log message "Removing claim messages which already exist in Pyxis" in "filter_claim_messages" method. This means that the timeout happened before the UMB messages were sent out. There are only a few candidates that could have caused the timeout in this part of the code, and all of them query Quay. Based on this I decided to add a timeout parameter to all of our queries done by the requests library.

Refers to CLOUDDST-11550