### PR TITLE
Remove the option for entrypoints to send UMB messages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ Connect to a remote host via ssh (using password) and perform the copying to mul
     --ssh-remote-host-port 2222 \
     --ssh-username user
 
-Connect to a remote host via ssh (using private key), perform the copying, and send a UMB message.
+Connect to a remote host via ssh (using private key), perform the copying
 ::
 
   $ export QUAY_PASSWORD=token
@@ -76,11 +76,6 @@ Connect to a remote host via ssh (using private key), perform the copying, and s
     --ssh-remote-host-port 2222 \
     --ssh-username user \
     --ssh-key-filename /path/to/file.key \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic
 
 Merge manifest lists of source-ref and dest-ref and overwrite dest-ref with the result.
 ::
@@ -91,7 +86,7 @@ Merge manifest lists of source-ref and dest-ref and overwrite dest-ref with the 
     --dest-ref quay.io/dest/image:1 \
     --quay-user quay+username
 
-Untag multiple images and send a UMB message.
+Untag multiple images
 ::
 
   $ export QUAY_PASSWORD=token
@@ -105,11 +100,6 @@ Untag multiple images and send a UMB message.
     --ssh-remote-host-port 2222 \
     --ssh-username user \
     --ssh-key-filename /path/to/file.key \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic
 
 Untag an image and force the operation in case the tag is a last reference of some digest.
 ::

--- a/docs/source/README.rst
+++ b/docs/source/README.rst
@@ -19,7 +19,6 @@ Requirements
 - Python 2.6+
 - Python 3.5+
 - Skopeo is required for the tagging operation
-- Internal Python library 'rhmsg' is required for sending UMB messages
 
 Setup
 =====

--- a/docs/source/clear_repo.rst
+++ b/docs/source/clear_repo.rst
@@ -3,7 +3,7 @@ Clear repo
 
 .. py:module:: pubtools._quay.clear_repo
 
-Entrypoint used for clearing Quay repositories. All images will be removed from the specified repo, while the repo will not be deleted. Signatures of the deleted images will be removed. Optionally, a UMB message will be sent notifying of the cleared repositories.
+Entrypoint used for clearing Quay repositories. All images will be removed from the specified repo, while the repo will not be deleted. Signatures of the deleted images will be removed.
 
 CLI reference
 -------------
@@ -21,7 +21,7 @@ API reference
 Examples
 -------------
 
-Clear multiple repos and send a UMB message.
+Clear multiple repos
 ::
 
   $ export QUAY_PASSWORD=token
@@ -32,8 +32,3 @@ Clear multiple repos and send a UMB message.
     --quay-user quay+username \
     --pyxis-server https://pyxis-server.com/ \
     --pyxis-krb-principal pyxis-principal \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic

--- a/docs/source/remove_repo.rst
+++ b/docs/source/remove_repo.rst
@@ -3,7 +3,7 @@ Remove repo
 
 .. py:module:: pubtools._quay.remove_repo
 
-Entrypoint used for removing Quay repositories. All the images along with the repository itself will be removed. Signatures of the deleted images will be removed. Optionally, a UMB message will be sent notifying of the removed repositories.
+Entrypoint used for removing Quay repositories. All the images along with the repository itself will be removed. Signatures of the deleted images will be removed.
 
 CLI reference
 -------------
@@ -21,7 +21,7 @@ API reference
 Examples
 -------------
 
-Clear multiple repos and send a UMB message.
+Clear multiple repos
 ::
 
   $ export QUAY_PASSWORD=token
@@ -32,8 +32,3 @@ Clear multiple repos and send a UMB message.
     --quay-user quay+username \
     --pyxis-server https://pyxis-server.com/ \
     --pyxis-krb-principal pyxis-principal \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic

--- a/docs/source/tag_images.rst
+++ b/docs/source/tag_images.rst
@@ -3,7 +3,7 @@ Tag images
 
 .. py:module:: pubtools._quay.tag_images
 
-Entrypoint used for copying an image to a destination/multiple destinations. If specified, copying operation may be performed on a remote machine via SSH. Optionally, a UMB message may be sent containing the information of tagged images.
+Entrypoint used for copying an image to a destination/multiple destinations. If specified, copying operation may be performed on a remote machine via SSH.
 
 
 CLI reference
@@ -58,7 +58,7 @@ Connect to a remote host via ssh (using password) and perform the copying to mul
     --ssh-remote-host-port 2222 \
     --ssh-username user
 
-Connect to a remote host via ssh (using private key), perform the copying, and send a UMB message.
+Connect to a remote host via ssh (using private key), perform the copying
 ::
 
   $ export QUAY_PASSWORD=token
@@ -72,11 +72,6 @@ Connect to a remote host via ssh (using private key), perform the copying, and s
     --ssh-remote-host-port 2222 \
     --ssh-username user \
     --ssh-key-filename /path/to/file.key \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic
 
 Copy to multiple destination inside a specified container.
 ::

--- a/docs/source/untag_images.rst
+++ b/docs/source/untag_images.rst
@@ -3,7 +3,7 @@ Untag images
 
 .. py:module:: pubtools._quay.untag_images
 
-Entrypoint used for removing tags (images) from Quay. The script will refuse to perform the removal if a last reference of an image is to be removed. This may be overruled by specifying the --remove-last flag. Optionally, an UMB message may be send notifying of the removed image tags.
+Entrypoint used for removing tags (images) from Quay. The script will refuse to perform the removal if a last reference of an image is to be removed. This may be overruled by specifying the --remove-last flag.
 
 CLI reference
 -------------
@@ -21,7 +21,7 @@ API reference
 Examples
 -------------
 
-Untag multiple images and send a UMB message.
+Untag multiple images
 ::
 
   $ export QUAY_PASSWORD=token
@@ -35,11 +35,6 @@ Untag multiple images and send a UMB message.
     --ssh-remote-host-port 2222 \
     --ssh-username user \
     --ssh-key-filename /path/to/file.key \
-    --send-umb-msg \
-    --umb-url amqps://url:5671 \
-    --umb-url amqps://url2:5671 \
-    --umb-cert /path/to/file.crt \
-    --umb-topic VirtualTopic.eng.pub.some_topic
 
 Untag an image and force the operation in case the tag is a last reference of some digest.
 ::

--- a/docs/source/utilities.rst
+++ b/docs/source/utilities.rst
@@ -7,7 +7,6 @@ Set of utilities used in various parts of the code
 
 .. autofunction:: setup_arg_parser
 .. autofunction:: add_args_env_variables
-.. autofunction:: send_umb_message
 .. autofunction:: capture_stdout
 .. autofunction:: setup_entry_point_cli
 .. autofunction:: run_entrypoint

--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -8,7 +8,6 @@ from .untag_images import untag_images
 from .utils.misc import (
     setup_arg_parser,
     add_args_env_variables,
-    send_umb_message,
     get_internal_container_repo_name,
 )
 
@@ -57,86 +56,7 @@ CLEAR_REPO_ARGS = {
         "required": True,
         "type": str,
     },
-    ("--send-umb-msg",): {
-        "help": "Flag of whether to send a UMB message",
-        "required": False,
-        "type": bool,
-    },
-    ("--umb-url",): {
-        "help": "UMB URL. More than one can be specified.",
-        "required": False,
-        "type": str,
-        "action": "append",
-    },
-    ("--umb-cert",): {
-        "help": "Path to the UMB certificate for SSL authentication.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-client-key",): {
-        "help": "Path to the UMB private key for accessing the certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-ca-cert",): {
-        "help": "Path to the UMB CA certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-topic",): {
-        "help": "UMB topic to send the message to.",
-        "required": False,
-        "type": str,
-        "default": "VirtualTopic.eng.pub.quay_clear_repositories",
-    },
 }
-
-
-def construct_kwargs(args):
-    """
-    Construct a kwargs dictionary based on the entered command line arguments.
-
-    Args:
-        args (argparse.Namespace):
-            Parsed command line arguments.
-
-    Returns (dict):
-        Keyword arguments for the 'clear_repositories' function.
-    """
-    kwargs = args.__dict__
-
-    # in args.__dict__ unspecified bool values have 'None' instead of 'False'
-    for name, attributes in CLEAR_REPO_ARGS.items():
-        if attributes["type"] is bool:
-            bool_var = name[0].lstrip("-").replace("-", "_")
-            if kwargs[bool_var] is None:
-                kwargs[bool_var] = False
-
-    # some exceptions have to be remapped
-    kwargs["umb_urls"] = kwargs.pop("umb_url")
-
-    return kwargs
-
-
-def verify_clear_repo_args(send_umb_msg, umb_urls, umb_cert):
-    """
-    Verify the presence and correctness of input parameters.
-
-    Args:
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
-    """
-    if send_umb_msg:
-        if not umb_urls:
-            raise ValueError("UMB URL must be specified if sending a UMB message was requested.")
-        if not umb_cert:
-            raise ValueError(
-                "A path to a client certificate must be provided when sending a UMB message."
-            )
 
 
 def clear_repositories(
@@ -148,12 +68,6 @@ def clear_repositories(
     pyxis_server,
     pyxis_ssl_crtfile,
     pyxis_ssl_keyfile,
-    send_umb_msg=False,
-    umb_urls=[],
-    umb_cert=None,
-    umb_client_key=None,
-    umb_ca_cert=None,
-    umb_topic="VirtualTopic.eng.pub.quay_clear_repositories",
 ):
     """
     Clear Quay repository.
@@ -175,21 +89,8 @@ def clear_repositories(
             Path to .crt file for SSL authentication.
         pyxis_ssl_keyfile (str):
             Path to .key file for SSL authentication.
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
-        umb_client_key (str):
-            Path to a client key to decrypt the certificate (if necessary).
-        umb_ca_cert (str):
-            Path to a CA certificate (for mutual authentication).
-        umb_topic (str):
-            Topic to send the UMB messages to.
     """
     parsed_repositories = repositories.split(",")
-    verify_clear_repo_args(send_umb_msg, umb_urls, umb_cert)
 
     LOG.info("Clearing repositories '{0}'".format(repositories))
     quay_client = QuayClient(quay_user, quay_password)
@@ -219,27 +120,10 @@ def clear_repositories(
         remove_last=True,
         quay_user=quay_user,
         quay_password=quay_password,
-        send_umb_msg=send_umb_msg,
-        umb_urls=umb_urls,
-        umb_cert=umb_cert,
-        umb_client_key=umb_client_key,
-        umb_ca_cert=umb_ca_cert,
     )
 
     LOG.info("Repositories have been cleared")
     pm.hook.quay_repositories_cleared(repository_ids=sorted(parsed_repositories))
-
-    if send_umb_msg:
-        LOG.info("Sending a UMB message")
-        props = {"cleared_repositories": parsed_repositories}
-        send_umb_message(
-            umb_urls,
-            props,
-            umb_cert,
-            umb_topic,
-            client_key=umb_client_key,
-            ca_cert=umb_ca_cert,
-        )
 
 
 def setup_args():
@@ -263,7 +147,7 @@ def clear_repositories_main(sysargs=None):
     if not args.quay_password:
         raise ValueError("--quay-password must be specified")
 
-    kwargs = construct_kwargs(args)
+    kwargs = args.__dict__
 
     with task_context():
         clear_repositories(**kwargs)

--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -99,7 +99,6 @@ class ContainerImagePusher:
             docker_cert_path=target_settings.get("docker_cert_path") or None,
             registry_username=target_settings.get("skopeo_executor_username") or None,
             registry_password=target_settings.get("skopeo_executor_password") or None,
-            send_umb_msg=False,
         )
 
         run_with_retries(

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -7,7 +7,6 @@ from .quay_api_client import QuayApiClient
 from .utils.misc import (
     setup_arg_parser,
     add_args_env_variables,
-    send_umb_message,
     get_internal_container_repo_name,
 )
 
@@ -56,86 +55,7 @@ REMOVE_REPO_ARGS = {
         "required": True,
         "type": str,
     },
-    ("--send-umb-msg",): {
-        "help": "Flag of whether to send a UMB message",
-        "required": False,
-        "type": bool,
-    },
-    ("--umb-url",): {
-        "help": "UMB URL. More than one can be specified.",
-        "required": False,
-        "type": str,
-        "action": "append",
-    },
-    ("--umb-cert",): {
-        "help": "Path to the UMB certificate for SSL authentication.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-client-key",): {
-        "help": "Path to the UMB private key for accessing the certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-ca-cert",): {
-        "help": "Path to the UMB CA certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-topic",): {
-        "help": "UMB topic to send the message to.",
-        "required": False,
-        "type": str,
-        "default": "VirtualTopic.eng.pub.quay_remove_repositories",
-    },
 }
-
-
-def construct_kwargs(args):
-    """
-    Construct a kwargs dictionary based on the entered command line arguments.
-
-    Args:
-        args (argparse.Namespace):
-            Parsed command line arguments.
-
-    Returns (dict):
-        Keyword arguments for the 'remove_repository' function.
-    """
-    kwargs = args.__dict__
-
-    # in args.__dict__ unspecified bool values have 'None' instead of 'False'
-    for name, attributes in REMOVE_REPO_ARGS.items():
-        if attributes["type"] is bool:
-            bool_var = name[0].lstrip("-").replace("-", "_")
-            if kwargs[bool_var] is None:
-                kwargs[bool_var] = False
-
-    # some exceptions have to be remapped
-    kwargs["umb_urls"] = kwargs.pop("umb_url")
-
-    return kwargs
-
-
-def verify_remove_repo_args(send_umb_msg, umb_urls, umb_cert):
-    """
-    Verify the presence and correctness of input parameters.
-
-    Args:
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
-    """
-    if send_umb_msg:
-        if not umb_urls:
-            raise ValueError("UMB URL must be specified if sending a UMB message was requested.")
-        if not umb_cert:
-            raise ValueError(
-                "A path to a client certificate must be provided when sending a UMB message."
-            )
 
 
 def remove_repositories(
@@ -147,12 +67,6 @@ def remove_repositories(
     pyxis_server,
     pyxis_ssl_crtfile,
     pyxis_ssl_keyfile,
-    send_umb_msg=False,
-    umb_urls=[],
-    umb_cert=None,
-    umb_client_key=None,
-    umb_ca_cert=None,
-    umb_topic="VirtualTopic.eng.pub.quay_remove_repository",
 ):
     """
     Remove Quay repository.
@@ -174,21 +88,8 @@ def remove_repositories(
             Path to .crt file for SSL authentication.
         pyxis_ssl_keyfile (str):
             Path to .key file for SSL authentication.
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
-        umb_client_key (str):
-            Path to a client key to decrypt the certificate (if necessary).
-        umb_ca_cert (str):
-            Path to a CA certificate (for mutual authentication).
-        umb_topic (str):
-            Topic to send the UMB messages to.
     """
     parsed_repositories = repositories.split(",")
-    verify_remove_repo_args(send_umb_msg, umb_urls, umb_cert)
 
     LOG.info("Removing repositories '{0}'".format(repositories))
     quay_api_client = QuayApiClient(quay_api_token)
@@ -209,18 +110,6 @@ def remove_repositories(
 
     LOG.info("Repositories have been removed")
     pm.hook.quay_repositories_removed(repository_ids=sorted(parsed_repositories))
-
-    if send_umb_msg:
-        LOG.info("Sending a UMB message")
-        props = {"removed_repositories": parsed_repositories}
-        send_umb_message(
-            umb_urls,
-            props,
-            umb_cert,
-            umb_topic,
-            client_key=umb_client_key,
-            ca_cert=umb_ca_cert,
-        )
 
 
 def setup_args():
@@ -244,7 +133,7 @@ def remove_repositories_main(sysargs=None):
     if not args.quay_password:
         raise ValueError("--quay-password must be specified")
 
-    kwargs = construct_kwargs(args)
+    kwargs = args.__dict__
 
     with task_context():
         remove_repositories(**kwargs)

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -619,7 +619,6 @@ class TagDocker:
             remove_last=remove_last,
             quay_user=target_settings["dest_quay_user"],
             quay_password=target_settings["dest_quay_password"],
-            send_umb_msg=False,
         )
 
     def untag_image(self, push_item, tag):

--- a/pubtools/_quay/untag_images.py
+++ b/pubtools/_quay/untag_images.py
@@ -3,7 +3,7 @@ import logging
 from pubtools.pluggy import pm, task_context
 
 from .image_untagger import ImageUntagger
-from .utils.misc import setup_arg_parser, add_args_env_variables, send_umb_message
+from .utils.misc import setup_arg_parser, add_args_env_variables
 
 LOG = logging.getLogger("pubtools.quay")
 
@@ -36,38 +36,6 @@ UNTAG_IMAGES_ARGS = {
         "type": str,
         "env_variable": "QUAY_PASSWORD",
     },
-    ("--send-umb-msg",): {
-        "help": "Flag of whether to send a UMB message",
-        "required": False,
-        "type": bool,
-    },
-    ("--umb-url",): {
-        "help": "UMB URL. More than one can be specified.",
-        "required": False,
-        "type": str,
-        "action": "append",
-    },
-    ("--umb-cert",): {
-        "help": "Path to the UMB certificate for SSL authentication.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-client-key",): {
-        "help": "Path to the UMB private key for accessing the certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-ca-cert",): {
-        "help": "Path to the UMB CA certificate.",
-        "required": False,
-        "type": str,
-    },
-    ("--umb-topic",): {
-        "help": "UMB topic to send the message to.",
-        "required": False,
-        "type": str,
-        "default": "VirtualTopic.eng.pub.quay_untag_image",
-    },
 }
 
 
@@ -93,14 +61,11 @@ def construct_kwargs(args):
 
     # some exceptions have to be remapped
     kwargs["references"] = kwargs.pop("reference")
-    kwargs["umb_urls"] = kwargs.pop("umb_url")
 
     return kwargs
 
 
-def verify_untag_images_args(
-    references, quay_user, quay_password, send_umb_msg, umb_urls, umb_cert
-):
+def verify_untag_images_args(references, quay_user, quay_password):
     """
     Verify the presence and correctness of input parameters.
 
@@ -111,12 +76,6 @@ def verify_untag_images_args(
             Quay username for Docker HTTP API.
         quay_password (str):
             Quay password for Docker HTTP API.
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
     """
     for reference in references:
         if "@" in reference:
@@ -125,14 +84,6 @@ def verify_untag_images_args(
     if (quay_user and not quay_password) or (quay_password and not quay_user):
         raise ValueError("Both user and password must be present when attempting to log in.")
 
-    if send_umb_msg:
-        if not umb_urls:
-            raise ValueError("UMB URL must be specified if sending a UMB message was requested.")
-        if not umb_cert:
-            raise ValueError(
-                "A path to a client certificate must be provided when sending a UMB message."
-            )
-
 
 def untag_images(
     references,
@@ -140,12 +91,6 @@ def untag_images(
     remove_last=False,
     quay_user=None,
     quay_password=None,
-    send_umb_msg=False,
-    umb_urls=[],
-    umb_cert=None,
-    umb_client_key=None,
-    umb_ca_cert=None,
-    umb_topic="VirtualTopic.eng.pub.quay_untag_image",
 ):
     """
     Untag images from Quay.
@@ -161,20 +106,8 @@ def untag_images(
             Quay username for Docker HTTP API.
         quay_password (str):
             Quay password for Docker HTTP API.
-        send_umb_msg (bool):
-            Whether to send UMB messages about the untagged images.
-        umb_urls ([str]):
-            AMQP broker URLs to connect to.
-        umb_cert (str):
-            Path to a certificate used for UMB authentication.
-        umb_client_key (str):
-            Path to a client key to decrypt the certificate (if necessary).
-        umb_ca_cert (str):
-            Path to a CA certificate (for mutual authentication).
-        umb_topic (str):
-            Topic to send the UMB messages to.
     """
-    verify_untag_images_args(references, quay_user, quay_password, send_umb_msg, umb_urls, umb_cert)
+    verify_untag_images_args(references, quay_user, quay_password)
 
     LOG.info("Started untagging operation with the following references: {0}".format(references))
     untagger = ImageUntagger(references, quay_api_token, remove_last, quay_user, quay_password)
@@ -182,18 +115,6 @@ def untag_images(
 
     LOG.info("Untagging operation succeeded")
     pm.hook.quay_images_untagged(untag_refs=sorted(references), lost_refs=sorted(lost_images))
-
-    if send_umb_msg:
-        LOG.info("Sending a UMB message")
-        props = {"untag_refs": references, "lost_refs": lost_images}
-        send_umb_message(
-            umb_urls,
-            props,
-            umb_cert,
-            umb_topic,
-            client_key=umb_client_key,
-            ca_cert=umb_ca_cert,
-        )
 
 
 def setup_args():

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -1,7 +1,6 @@
 import argparse
 import contextlib
 import functools
-import json
 import logging
 import os
 import pkg_resources
@@ -72,40 +71,6 @@ def add_args_env_variables(parsed_args, args):
             if not getattr(parsed_args, named_alias) and os.environ.get(arg_data["env_variable"]):
                 setattr(parsed_args, named_alias, os.environ.get(arg_data["env_variable"]))
     return parsed_args
-
-
-def send_umb_message(urls, props, cert, topic, body=None, client_key=None, ca_cert=None):
-    """
-    Send a UMB message.
-
-    Args:
-        urls ([str]):
-            URLs to send the message to.
-        props (dict):
-            Message properties dictionary.
-        cert (str):
-            Path to certificate for SSL authentication.
-        topic (str):
-            Topic to send the message to.
-        body (str):
-            Body of the message.
-        client_key (str):
-            Path to a private key for accessing the certificate.
-        ca_cert (str):
-            Path to CA certificate.
-    """
-    from rhmsg.activemq.producer import AMQProducer
-
-    producer = AMQProducer(
-        urls=urls,
-        certificate=cert,
-        private_key=client_key,
-        topic=topic,
-        trusted_certificates=ca_cert,
-    )
-    if not body:
-        body = json.dumps(props).encode("utf-8")
-    producer.send_msg(props, body)
 
 
 @contextlib.contextmanager

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,3 @@ pubtools>=0.3.0
 iiblib
 pubtools-iib
 pykerberos
-
-# -e git+https://code.engineering.redhat.com/gerrit/rhmsg#egg=rhmsg-0.9

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -72,15 +72,9 @@ def test_arg_parser_required_args(mock_tag_images):
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
-        send_umb_msg=False,
-        umb_cert=None,
-        umb_client_key=None,
-        umb_ca_cert=None,
         registry_username=None,
         registry_password=None,
-        umb_topic="VirtualTopic.eng.pub.quay_tag_image",
         dest_refs=["quay.io/repo/target-image:1"],
-        umb_urls=None,
     )
 
 
@@ -126,17 +120,6 @@ def test_arg_parser_full_args(mock_tag_images):
         "registry_user",
         "--registry-password",
         "registry_passwd",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-        "--umb-cert",
-        "/path/to/file.crt",
-        "--umb-client-key",
-        "/path/to/umb.key",
-        "--umb-ca-cert",
-        "/path/to/ca_cert.crt",
-        "--umb-topic",
-        "VirtualTopic.eng.pub.tagimage",
     ]
     tag_images.tag_images_main(full_args)
 
@@ -162,13 +145,7 @@ def test_arg_parser_full_args(mock_tag_images):
         docker_cert_path="/some/path",
         registry_username="registry_user",
         registry_password="registry_passwd",
-        send_umb_msg=True,
-        umb_cert="/path/to/file.crt",
-        umb_client_key="/path/to/umb.key",
-        umb_ca_cert="/path/to/ca_cert.crt",
-        umb_topic="VirtualTopic.eng.pub.tagimage",
         dest_refs=["quay.io/repo/target-image:1"],
-        umb_urls=["amqps://url:5671"],
     )
 
 
@@ -182,13 +159,6 @@ def test_arg_parser_multiple_args(mock_tag_images):
         "quay.io/repo/target-image:1",
         "--dest-ref",
         "quay.io/repo/target-image:2",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url1:5671",
-        "--umb-url",
-        "amqps://url2:5671",
-        "--umb-cert",
-        "/path/to/file.crt",
     ]
     tag_images.tag_images_main(multi_args)
 
@@ -212,15 +182,9 @@ def test_arg_parser_multiple_args(mock_tag_images):
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
-        send_umb_msg=True,
-        umb_cert="/path/to/file.crt",
-        umb_client_key=None,
-        umb_ca_cert=None,
         registry_username=None,
         registry_password=None,
-        umb_topic="VirtualTopic.eng.pub.quay_tag_image",
         dest_refs=["quay.io/repo/target-image:1", "quay.io/repo/target-image:2"],
-        umb_urls=["amqps://url1:5671", "amqps://url2:5671"],
     )
 
 
@@ -324,38 +288,6 @@ def test_arg_parser_missing_quay_user_or_password():
         tag_images.tag_images_main(missing_source_user)
 
 
-def test_arg_parser_missing_umb_url():
-    missing_umb_url = [
-        "dummy",
-        "--source-ref",
-        "quay.io/repo/souce-image:1",
-        "--dest-ref",
-        "quay.io/repo/target-image:1",
-        "--send-umb-msg",
-        "--umb-cert",
-        "/path/to/file.crt",
-    ]
-
-    with pytest.raises(ValueError, match="UMB URL must be specified.*"):
-        tag_images.tag_images_main(missing_umb_url)
-
-
-def test_arg_parser_missing_umb_cert():
-    missing_umb_url = [
-        "dummy",
-        "--source-ref",
-        "quay.io/repo/souce-image:1",
-        "--dest-ref",
-        "quay.io/repo/target-image:1",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url1:5671",
-    ]
-
-    with pytest.raises(ValueError, match="A path to a client certificate.*"):
-        tag_images.tag_images_main(missing_umb_url)
-
-
 def test_arg_parser_missing_container_image():
     missing_umb_url = [
         "dummy",
@@ -399,19 +331,8 @@ def test_arg_parser_env_variables(mock_tag_images):
         "dummy",
         "--ssh-key-filename",
         "/path/to/file.key",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-        "--umb-cert",
-        "/path/to/file.crt",
-        "--umb-client-key",
-        "/path/to/umb.key",
-        "--umb-ca-cert",
-        "/path/to/ca_cert.crt",
         "--registry-username",
         "registry_user",
-        "--umb-topic",
-        "VirtualTopic.eng.pub.tagimage",
     ]
     tag_images.tag_images_main(full_args)
 
@@ -435,13 +356,7 @@ def test_arg_parser_env_variables(mock_tag_images):
         docker_timeout=None,
         docker_verify_tls=False,
         docker_cert_path=None,
-        send_umb_msg=True,
-        umb_cert="/path/to/file.crt",
-        umb_client_key="/path/to/umb.key",
-        umb_ca_cert="/path/to/ca_cert.crt",
         registry_username="registry_user",
         registry_password="registry_passwd",
-        umb_topic="VirtualTopic.eng.pub.tagimage",
         dest_refs=["quay.io/repo/target-image:1"],
-        umb_urls=["amqps://url:5671"],
     )

--- a/tests/test_clear_repo.py
+++ b/tests/test_clear_repo.py
@@ -36,7 +36,6 @@ def test_arg_constructor_required_args(mock_clear_repositories):
     assert called_args["pyxis_server"] == "pyxis-url.com"
     assert called_args["pyxis_ssl_crtfile"] == "/path/to/file.crt"
     assert called_args["pyxis_ssl_keyfile"] == "/path/to/file.key"
-    assert called_args["umb_topic"] == "VirtualTopic.eng.pub.quay_clear_repositories"
 
 
 @mock.patch.dict("os.environ", {"QUAY_API_TOKEN": "api_token", "QUAY_PASSWORD": "some-password"})
@@ -56,19 +55,6 @@ def test_arg_constructor_all_args(mock_clear_repositories):
         "/path/to/file.crt",
         "--pyxis-ssl-keyfile",
         "/path/to/file.key",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-        "--umb-url",
-        "amqps://url:5672",
-        "--umb-cert",
-        "/path/to/file.crt",
-        "--umb-client-key",
-        "/path/to/umb.key",
-        "--umb-ca-cert",
-        "/path/to/ca_cert.crt",
-        "--umb-topic",
-        "VirtualTopic.eng.pub.clear_repo_new",
     ]
     clear_repo.clear_repositories_main(all_args)
     _, called_args = mock_clear_repositories.call_args
@@ -80,13 +66,7 @@ def test_arg_constructor_all_args(mock_clear_repositories):
     assert called_args["pyxis_server"] == "pyxis-url.com"
     assert called_args["pyxis_ssl_crtfile"] == "/path/to/file.crt"
     assert called_args["pyxis_ssl_keyfile"] == "/path/to/file.key"
-    assert called_args["send_umb_msg"] is True
-    assert called_args["umb_urls"] == ["amqps://url:5671", "amqps://url:5672"]
-    assert called_args["umb_cert"] == "/path/to/file.crt"
-    assert called_args["umb_client_key"] == "/path/to/umb.key"
-    assert called_args["umb_ca_cert"] == "/path/to/ca_cert.crt"
     assert called_args["quay_api_token"] == "api_token"
-    assert called_args["umb_topic"] == "VirtualTopic.eng.pub.clear_repo_new"
 
 
 @mock.patch("pubtools._quay.clear_repo.clear_repositories")
@@ -169,77 +149,10 @@ def test_args_missing_quay_password(mock_clear_repositories):
     mock_clear_repositories.assert_not_called()
 
 
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
-@mock.patch("pubtools._quay.clear_repo.QuayClient")
-def test_args_missing_umb_url(mock_quay_client, mock_send_umb_message):
-    wrong_args = [
-        "dummy",
-        "--repositories",
-        "namespace/image",
-        "--quay-org",
-        "quay-organization",
-        "--quay-user",
-        "some-user",
-        "--quay-password",
-        "some-password",
-        "--quay-api-token",
-        "some-token",
-        "--pyxis-server",
-        "pyxis-url.com",
-        "--pyxis-ssl-crtfile",
-        "/path/to/file.crt",
-        "--pyxis-ssl-keyfile",
-        "/path/to/file.key",
-        "--send-umb-msg",
-        "--umb-cert",
-        "/path/to/file.crt",
-    ]
-
-    with pytest.raises(ValueError, match="UMB URL must be specified.*"):
-        clear_repo.clear_repositories_main(wrong_args)
-
-    mock_quay_client.assert_not_called()
-    mock_send_umb_message.assert_not_called()
-
-
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
-@mock.patch("pubtools._quay.clear_repo.QuayClient")
-def test_args_missing_umb_cert(mock_quay_client, mock_send_umb_message):
-    wrong_args = [
-        "dummy",
-        "--repositories",
-        "namespace/image",
-        "--quay-org",
-        "quay-organization",
-        "--quay-user",
-        "some-user",
-        "--quay-password",
-        "some-password",
-        "--quay-api-token",
-        "some-token",
-        "--pyxis-server",
-        "pyxis-url.com",
-        "--pyxis-ssl-crtfile",
-        "/path/to/file.crt",
-        "--pyxis-ssl-keyfile",
-        "/path/to/file.key",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-    ]
-
-    with pytest.raises(ValueError, match="A path to a client certificate.*"):
-        clear_repo.clear_repositories_main(wrong_args)
-
-    mock_quay_client.assert_not_called()
-    mock_send_umb_message.assert_not_called()
-
-
 @mock.patch("pubtools._quay.clear_repo.untag_images")
 @mock.patch("pubtools._quay.clear_repo.SignatureRemover")
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
 @mock.patch("pubtools._quay.clear_repo.QuayClient")
-def test_run(mock_quay_client, mock_send_umb_message, mock_signature_remover, mock_untag_images):
+def test_run(mock_quay_client, mock_signature_remover, mock_untag_images):
     args = [
         "dummy",
         "--repositories",
@@ -291,22 +204,13 @@ def test_run(mock_quay_client, mock_send_umb_message, mock_signature_remover, mo
         remove_last=True,
         quay_user="some-user",
         quay_password="some-password",
-        send_umb_msg=False,
-        umb_urls=None,
-        umb_cert=None,
-        umb_client_key=None,
-        umb_ca_cert=None,
     )
-    mock_send_umb_message.assert_not_called()
 
 
 @mock.patch("pubtools._quay.clear_repo.untag_images")
 @mock.patch("pubtools._quay.clear_repo.SignatureRemover")
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
 @mock.patch("pubtools._quay.clear_repo.QuayClient")
-def test_run_multiple_repos(
-    mock_quay_client, mock_send_umb_message, mock_signature_remover, mock_untag_images, hookspy
-):
+def test_run_multiple_repos(mock_quay_client, mock_signature_remover, mock_untag_images, hookspy):
     args = [
         "dummy",
         "--repositories",
@@ -377,13 +281,7 @@ def test_run_multiple_repos(
         remove_last=True,
         quay_user="some-user",
         quay_password="some-password",
-        send_umb_msg=False,
-        umb_urls=None,
-        umb_cert=None,
-        umb_client_key=None,
-        umb_ca_cert=None,
     )
-    mock_send_umb_message.assert_not_called()
 
     # Should have activated these hooks.
     assert hookspy == [
@@ -394,85 +292,3 @@ def test_run_multiple_repos(
         ),
         ("task_stop", {"failed": False}),
     ]
-
-
-@mock.patch("pubtools._quay.clear_repo.untag_images")
-@mock.patch("pubtools._quay.clear_repo.SignatureRemover")
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
-@mock.patch("pubtools._quay.clear_repo.QuayClient")
-def test_send_umb_message(
-    mock_quay_client, mock_send_umb_message, mock_signature_remover, mock_untag_images
-):
-    args = [
-        "dummy",
-        "--repositories",
-        "namespace/image",
-        "--quay-org",
-        "quay-organization",
-        "--quay-user",
-        "some-user",
-        "--quay-password",
-        "some-password",
-        "--quay-api-token",
-        "some-token",
-        "--pyxis-server",
-        "pyxis-url.com",
-        "--pyxis-ssl-crtfile",
-        "/path/to/file.crt",
-        "--pyxis-ssl-keyfile",
-        "/path/to/file.key",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-        "--umb-cert",
-        "/path/to/file.crt",
-        "--umb-client-key",
-        "/path/to/umb.key",
-        "--umb-ca-cert",
-        "/path/to/ca_cert.crt",
-        "--umb-topic",
-        "VirtualTopic.eng.pub.clear_repo_new",
-    ]
-    mock_get_repo_tags = mock.MagicMock()
-    mock_get_repo_tags.return_value = {"tags": ["1", "2"]}
-    mock_quay_client.return_value.get_repository_tags = mock_get_repo_tags
-    mock_set_quay_client = mock.MagicMock()
-    mock_remove_repository_signatures = mock.MagicMock()
-    mock_signature_remover.return_value.set_quay_client = mock_set_quay_client
-    mock_signature_remover.return_value.remove_repository_signatures = (
-        mock_remove_repository_signatures
-    )
-    clear_repo.clear_repositories_main(args)
-
-    mock_set_quay_client.assert_called_once_with(mock_quay_client.return_value)
-    mock_remove_repository_signatures.assert_called_once_with(
-        "namespace/image",
-        "quay-organization",
-        "pyxis-url.com",
-        "/path/to/file.crt",
-        "/path/to/file.key",
-    )
-    mock_get_repo_tags.assert_called_once_with("quay-organization/namespace----image")
-    mock_untag_images.assert_called_once_with(
-        [
-            "quay.io/quay-organization/namespace----image:1",
-            "quay.io/quay-organization/namespace----image:2",
-        ],
-        "some-token",
-        remove_last=True,
-        quay_user="some-user",
-        quay_password="some-password",
-        send_umb_msg=True,
-        umb_urls=["amqps://url:5671"],
-        umb_cert="/path/to/file.crt",
-        umb_client_key="/path/to/umb.key",
-        umb_ca_cert="/path/to/ca_cert.crt",
-    )
-    mock_send_umb_message.assert_called_once_with(
-        ["amqps://url:5671"],
-        {"cleared_repositories": ["namespace/image"]},
-        "/path/to/file.crt",
-        "VirtualTopic.eng.pub.clear_repo_new",
-        client_key="/path/to/umb.key",
-        ca_cert="/path/to/ca_cert.crt",
-    )

--- a/tests/test_container_pusher.py
+++ b/tests/test_container_pusher.py
@@ -62,7 +62,6 @@ def test_tag_images(
         docker_cert_path=None,
         registry_username="quay-executor-user",
         registry_password="quay-executor-password",
-        send_umb_msg=False,
     )
 
 
@@ -102,7 +101,6 @@ def test_tag_images_retry(
         docker_cert_path=None,
         registry_username="quay-executor-user",
         registry_password="quay-executor-password",
-        send_umb_msg=False,
     )
 
     assert mock_tag_images.call_count == 3
@@ -140,7 +138,6 @@ def test_copy_src_item(
         docker_cert_path=None,
         registry_username="quay-executor-user",
         registry_password="quay-executor-password",
-        send_umb_msg=False,
         source_quay_password="src-quay-pass",
         source_quay_user="src-quay-user",
     )
@@ -175,7 +172,6 @@ def test_copy_v1_item(
         docker_cert_path=None,
         registry_username="quay-executor-user",
         registry_password="quay-executor-password",
-        send_umb_msg=False,
     )
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -18,7 +18,6 @@ from .utils.misc import sort_dictionary_sortable_values, compare_logs, IIBRes
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.command_executor.APIClient")
 @mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
@@ -30,7 +29,6 @@ def test_push_docker_multiarch_merge_ml_operator(
     mock_claims_handler,
     mock_proton,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_run_entrypoint_operator_pusher,
     mock_api_client,
     mock_run_entrypoint_signature_remover,
@@ -235,7 +233,6 @@ def test_push_docker_multiarch_merge_ml_operator(
 
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
@@ -247,7 +244,6 @@ def test_push_docker_multiarch_simple_workflow(
     mock_claims_handler,
     mock_proton,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_api_client,
     mock_run_entrypoint_signature_remover,
     target_settings,
@@ -386,7 +382,6 @@ def test_push_docker_multiarch_simple_workflow(
 @mock.patch("pubtools._quay.push_docker.PushDocker.fetch_missing_push_items_digests")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
@@ -398,7 +393,6 @@ def test_push_docker_source(
     mock_claims_handler,
     mock_proton,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_api_client,
     mock_run_entrypoint_signature_remover,
     mock_fetch_missing_push_items_digests,
@@ -556,7 +550,6 @@ def test_push_docker_source(
 
 
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.proton")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
@@ -568,7 +561,6 @@ def test_push_docker_multiarch_rollback(
     mock_claims_handler,
     mock_proton,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_run_entrypoint_signature_remover,
     target_settings,
     container_multiarch_push_item_integration,
@@ -849,8 +841,6 @@ def test_tag_docker_multiarch_merge_ml(
 
 
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.untag_images.send_umb_message")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
@@ -862,8 +852,6 @@ def test_tag_docker_source_copy_untag(
     mock_run_entrypoint_sig_remover,
     mock_claims_handler,
     mock_run_cmd,
-    mock_send_umb_message_tag,
-    mock_send_umb_message_untag,
     mock_api_client,
     target_settings,
     tag_docker_push_item_add_integration,
@@ -1026,7 +1014,6 @@ def test_tag_docker_source_copy_untag(
 
 
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
@@ -1040,7 +1027,6 @@ def test_task_iib_add_bundles(
     mock_run_entrypoint_signature_handler,
     mock_run_entrypoint_signature_remover,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_api_client,
     target_settings,
     src_manifest_list,
@@ -1102,7 +1088,6 @@ def test_task_iib_add_bundles(
 
 
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
@@ -1114,7 +1099,6 @@ def test_task_iib_remove_operators(
     mock_run_entrypoint_signature_handler,
     mock_run_entrypoint_signature_remover,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_api_client,
     target_settings,
     src_manifest_list,
@@ -1175,7 +1159,6 @@ def test_task_iib_remove_operators(
 
 
 @mock.patch("pubtools._quay.command_executor.APIClient")
-@mock.patch("pubtools._quay.tag_images.send_umb_message")
 @mock.patch("pubtools._quay.command_executor.RemoteExecutor._run_cmd")
 @mock.patch("pubtools._quay.signature_handler.run_entrypoint")
 @mock.patch("pubtools._quay.signature_handler.ManifestClaimsHandler")
@@ -1185,7 +1168,6 @@ def test_task_iib_build_from_scratch(
     mock_manifest_claims_handler,
     mock_run_entrypoint_signature_handler,
     mock_run_cmd,
-    mock_send_umb_message,
     mock_api_client,
     target_settings,
     src_manifest_list,
@@ -1222,13 +1204,9 @@ def test_task_iib_build_from_scratch(
         )
 
 
-@mock.patch("pubtools._quay.untag_images.send_umb_message")
-@mock.patch("pubtools._quay.clear_repo.send_umb_message")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 def test_clear_repo(
     mock_run_entrypoint_signature_remover,
-    mock_send_umb_message_clear_repo,
-    mock_send_umb_message_untag_images,
     src_manifest_list,
 ):
 
@@ -1303,15 +1281,12 @@ def test_clear_repo(
             pyxis_server="pyxis-server.com",
             pyxis_ssl_crtfile="/path/to/file.crt",
             pyxis_ssl_keyfile="/path/to/file.key",
-            send_umb_msg=False,
         )
 
 
-@mock.patch("pubtools._quay.remove_repo.send_umb_message")
 @mock.patch("pubtools._quay.signature_remover.run_entrypoint")
 def test_remove_repo(
     mock_run_entrypoint_signature_remover,
-    mock_send_umb_message_clear_repo,
     src_manifest_list,
 ):
 
@@ -1383,5 +1358,4 @@ def test_remove_repo(
             pyxis_server="pyxis-server.com",
             pyxis_ssl_crtfile="/path/to/file.crt",
             pyxis_ssl_keyfile="/path/to/file.key",
-            send_umb_msg=False,
         )

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -1872,7 +1872,6 @@ def test_run_untag_images_remove_last(mock_untag_images, target_settings):
         remove_last=True,
         quay_user="dest-quay-user",
         quay_password="dest-quay-pass",
-        send_umb_msg=False,
     )
 
 
@@ -1888,7 +1887,6 @@ def test_run_untag_images_dont_remove_last(mock_untag_images, target_settings):
         remove_last=False,
         quay_user="dest-quay-user",
         quay_password="dest-quay-pass",
-        send_umb_msg=False,
     )
 
 

--- a/tests/test_tag_entrypoint.py
+++ b/tests/test_tag_entrypoint.py
@@ -1,4 +1,3 @@
-import json
 import sys
 
 import mock
@@ -154,56 +153,3 @@ def test_run_tag_entrypoint_container_success(mock_container_executor):
     mock_tag_images.assert_called_once_with(
         "quay.io/repo/souce-image:1", ["quay.io/repo/target-image:1"], False
     )
-
-
-@mock.patch("pubtools._quay.tag_images.LocalExecutor")
-@mock.patch("rhmsg.activemq.producer.AMQProducer")
-def test_run_tag_entrypoint_send_umb(mock_amq_producer, mock_local_executor):
-    args = [
-        "dummy",
-        "--source-ref",
-        "quay.io/repo/souce-image:1",
-        "--dest-ref",
-        "quay.io/repo/target-image:1",
-        "--send-umb-msg",
-        "--umb-url",
-        "amqps://url:5671",
-        "--umb-cert",
-        "/path/to/file.crt",
-        "--umb-client-key",
-        "/path/to/umb.key",
-        "--umb-ca-cert",
-        "/path/to/ca_cert.crt",
-        "--umb-topic",
-        "VirtualTopic.eng.pub.tagimage",
-    ]
-    module_mock.AMQProducer = mock_amq_producer
-    mock_skopeo_login = mock.MagicMock()
-    mock_local_executor.return_value.skopeo_login = mock_skopeo_login
-    mock_local_executor.return_value.__enter__.return_value = mock_local_executor.return_value
-    mock_tag_images = mock.MagicMock()
-    mock_local_executor.return_value.tag_images = mock_tag_images
-
-    mock_send_msg = mock.MagicMock()
-    mock_amq_producer.return_value.send_msg = mock_send_msg
-
-    tag_images.tag_images_main(args)
-
-    mock_local_executor.assert_called_once_with()
-    mock_skopeo_login.assert_called_once_with("quay.io", None, None)
-    mock_tag_images.assert_called_once_with(
-        "quay.io/repo/souce-image:1", ["quay.io/repo/target-image:1"], False
-    )
-
-    mock_amq_producer.assert_called_once_with(
-        urls=["amqps://url:5671"],
-        certificate="/path/to/file.crt",
-        private_key="/path/to/umb.key",
-        topic="VirtualTopic.eng.pub.tagimage",
-        trusted_certificates="/path/to/ca_cert.crt",
-    )
-    expected = {
-        "source_ref": "quay.io/repo/souce-image:1",
-        "dest_refs": ["quay.io/repo/target-image:1"],
-    }
-    mock_send_msg.assert_called_once_with(expected, json.dumps(expected).encode("utf-8"))


### PR DESCRIPTION
This capability was initially implemented due to a misunderstanding
with the Metaxor team, which captures UMB messages to know what
metadata to refresh. Pub creates a UMB message for each new task,
which is what Metaxor currently captures. This means that it's
unnecessary to generate these messages by the entrypoints themselves,
as they share no real purpose and are not consumed by anyone. Removing
this functionality simplifies the code and removes a requirement to
install an internal dependency.