### PR TITLE
Change pykerberos to kerberos

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ docker
 pubtools>=0.3.0
 iiblib
 pubtools-iib
-pykerberos
+kerberos
 
 # -e git+https://code.engineering.redhat.com/gerrit/rhmsg#egg=rhmsg-0.9


### PR DESCRIPTION
pykerberos is not valid distribution for RPMs. We should use "kerberos" instead