### PR TITLE
Remove sorting of Push items

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -539,7 +539,7 @@ class PushDocker:
             push_items(list): List of push items.
             target_settings(dict): Target settings.
         """
-        for item in sorted(push_items):
+        for item in push_items:
             item.metadata["new_digests"] = {}
             missing_media_types = set(
                 [QuayClient.MANIFEST_V2S2_TYPE, QuayClient.MANIFEST_V2S1_TYPE]


### PR DESCRIPTION
Since push items are not natively sortable, sorting causes errors in
Python 3. There's no real reason for sorting the push items here, so
remove it.

Refers to CLOUDDST-13071