### PR TITLE
Unpin the version of python-qpid-proton in pubtools-quay installation

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ pubtools-pyxis
 pyrsistent==0.15.7;python_version<'3.0'
 pushcollector
 PyHamcrest
+python-qpid-proton==0.33.0;python_version<'3.0'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ paramiko
 requests
 pubtools-pyxis
 six
-python-qpid-proton==0.33.0
+python-qpid-proton
 monotonic
 docker
 pubtools>=0.3.0


### PR DESCRIPTION
The version of python-qpid-proton was originally pinned to 0.33.0 so
that the Python 2 test suite would pass. However, this constraint has no
reason to exist during Python 3 installation, and causes issues when
pubtools-quay is invoked as a console script. Move the version
constraint to requirements-test.txt and only apply it to Python 2.