### PR TITLE
Change condition to not require hashing

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -639,7 +639,7 @@ class PushDocker:
             # Push index images to Quay
             operator_pusher.push_index_images(successful_iib_results, index_stamp)
             # Rollback only when all index image builds fails
-            if set([x["iib_result"] for x in iib_results.values()]) == set([False]):
+            if not any([x["iib_result"] for x in iib_results.values()]):
                 LOG.error("Push of all index images failed, running rollback.")
                 self.rollback(backup_tags, rollback_tags)
                 failed = True


### PR DESCRIPTION
The condition checking for IIB failures fails on Python 3, since it
attempts to hash an unhashable object. This happens during an attempt to
create a set from a list containing a mix of iiblib models and Falses.
IIBlib models are appearently not hashable on Python 3. Change the
condition to not require hashing.