### PR TITLE
Poll for consistent results of whether a tag exists

### DIFF
--- a/docs/source/push_docker.rst
+++ b/docs/source/push_docker.rst
@@ -15,5 +15,6 @@ This is the main class for the Push Docker workflow, which is the primary workfl
    .. automethod:: get_repo_metadata
    .. automethod:: check_repos_validity
    .. automethod:: generate_backup_mapping
+   .. automethod:: _poll_tag_inconsistency
    .. automethod:: rollback
    .. automethod:: remove_old_signatures

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -836,6 +836,277 @@ def test_generate_backup_mapping_server_error(
     assert mock_get_repository_tags.call_count == 2
 
 
+@mock.patch("pubtools._quay.push_docker.PushDocker._poll_tag_inconsistency")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_generate_backup_mapping_tag_inconsistency(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_poll_tag_inconsistency,
+    target_settings,
+    container_multiarch_push_item,
+):
+    hub = mock.MagicMock()
+
+    response = mock.MagicMock()
+    response.status_code = 404
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": ["latest-test-tag"]}
+
+    mock_poll_tag_inconsistency.return_value = None
+
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.side_effect = (
+        requests.exceptions.HTTPError("not found", response=response),
+    )
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    mock_get_manifest = mock.MagicMock()
+    mock_quay_client.return_value.get_manifest = mock_get_manifest
+
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+    backup_tags, rollback_tags = push_docker_instance.generate_backup_mapping(
+        [container_multiarch_push_item]
+    )
+    assert backup_tags == {}
+    assert rollback_tags == [
+        push_docker.PushDocker.ImageData(
+            repo="some-namespace/target----repo",
+            tag="latest-test-tag",
+            digest=None,
+            v2s1_digest=None,
+        ),
+    ]
+    assert mock_get_repository_tags.call_count == 1
+    assert mock_get_repository_tags.call_args_list[0] == mock.call("some-namespace/target----repo")
+
+    assert mock_get_manifest.call_count == 0
+
+    mock_poll_tag_inconsistency.assert_called_once_with(
+        "some-namespace/target----repo", "latest-test-tag"
+    )
+
+
+@mock.patch("pubtools._quay.push_docker.PushDocker._poll_tag_inconsistency")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_generate_backup_mapping_tag_inconsistency_uncaught_error(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_poll_tag_inconsistency,
+    target_settings,
+    container_multiarch_push_item,
+):
+    hub = mock.MagicMock()
+
+    response = mock.MagicMock()
+    response.status_code = 500
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": ["latest-test-tag"]}
+
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.side_effect = (
+        requests.exceptions.HTTPError("server error", response=response),
+    )
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+    with pytest.raises(requests.exceptions.HTTPError, match=".*server error.*"):
+        push_docker_instance.generate_backup_mapping([container_multiarch_push_item])
+
+    assert mock_get_repository_tags.call_count == 1
+    assert mock_get_repository_tags.call_args_list[0] == mock.call("some-namespace/target----repo")
+
+    mock_poll_tag_inconsistency.assert_not_called()
+
+
+@mock.patch("pubtools._quay.push_docker.sleep")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_poll_tag_inconsistency_found_match(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_sleep,
+    target_settings,
+    container_multiarch_push_item,
+):
+
+    hub = mock.MagicMock()
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": ["latest-test-tag"]}
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.return_value = "sha256:a1a1a1a1a1a1"
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    digest = push_docker_instance._poll_tag_inconsistency(
+        "some-namespace/target----repo", "latest-test-tag"
+    )
+    assert digest == "sha256:a1a1a1a1a1a1"
+    mock_sleep.assert_called_once_with(30)
+    mock_get_repository_tags.assert_called_once_with("some-namespace/target----repo")
+    mock_get_manifest_digest.assert_called_once_with(
+        "quay.io/some-namespace/target----repo:latest-test-tag"
+    )
+
+
+@mock.patch("pubtools._quay.push_docker.sleep")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_poll_tag_inconsistency_tag_doesnt_exist(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_sleep,
+    target_settings,
+    container_multiarch_push_item,
+):
+
+    hub = mock.MagicMock()
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": []}
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+
+    response = mock.MagicMock()
+    response.status_code = 404
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.side_effect = requests.exceptions.HTTPError(
+        "not found", response=response
+    )
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    digest = push_docker_instance._poll_tag_inconsistency(
+        "some-namespace/target----repo", "latest-test-tag"
+    )
+    assert digest == None
+    mock_sleep.assert_called_once_with(30)
+    mock_get_repository_tags.assert_called_once_with("some-namespace/target----repo")
+    mock_get_manifest_digest.assert_called_once_with(
+        "quay.io/some-namespace/target----repo:latest-test-tag"
+    )
+
+
+@mock.patch("pubtools._quay.push_docker.sleep")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_poll_tag_inconsistency_timeout_reached(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_sleep,
+    target_settings,
+    container_multiarch_push_item,
+    caplog,
+):
+    caplog.set_level(logging.WARNING)
+    hub = mock.MagicMock()
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": ["latest-test-tag"]}
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+
+    response = mock.MagicMock()
+    response.status_code = 404
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.side_effect = requests.exceptions.HTTPError(
+        "not found", response=response
+    )
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    digest = push_docker_instance._poll_tag_inconsistency(
+        "some-namespace/target----repo", "latest-test-tag"
+    )
+    assert digest == None
+    assert mock_sleep.call_count == 4
+    assert mock_get_repository_tags.call_count == 4
+    assert mock_get_manifest_digest.call_count == 4
+
+    expected_logs = [
+        ".*determine if image 'quay.io/some-namespace/target----repo:latest-test-tag' exists.*",
+    ]
+    compare_logs(caplog, expected_logs)
+
+
+@mock.patch("pubtools._quay.push_docker.sleep")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_poll_tag_inconsistency_server_error(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_sleep,
+    target_settings,
+    container_multiarch_push_item,
+):
+
+    hub = mock.MagicMock()
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_push_item],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+
+    mock_get_repository_tags = mock.MagicMock()
+    mock_get_repository_tags.return_value = {"name": "target----repo", "tags": []}
+    mock_quay_client.return_value.get_repository_tags = mock_get_repository_tags
+
+    response = mock.MagicMock()
+    response.status_code = 500
+    mock_get_manifest_digest = mock.MagicMock()
+    mock_get_manifest_digest.side_effect = requests.exceptions.HTTPError(
+        "server error", response=response
+    )
+    mock_quay_client.return_value.get_manifest_digest = mock_get_manifest_digest
+
+    with pytest.raises(requests.exceptions.HTTPError, match=".*server error.*"):
+        push_docker_instance._poll_tag_inconsistency(
+            "some-namespace/target----repo", "latest-test-tag"
+        )
+
+    mock_sleep.assert_called_once_with(30)
+    mock_get_repository_tags.assert_called_once_with("some-namespace/target----repo")
+    mock_get_manifest_digest.assert_called_once_with(
+        "quay.io/some-namespace/target----repo:latest-test-tag"
+    )
+
+
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_rollback(


### PR DESCRIPTION
It's possible that Docker HTTP API will claim that a tag exists, but
trying to get digest of this tag results in a 404. It can't be
determined which source is right, so poll both until the results are
consistent. If the tag ends up not existing, add it to rollback tags,
and if it begins to exist continue with the backup tags workflow. The
polling will not happen indefinitely, at some point the method will give
up and assume that the tag doesn't exist.

Refers to CLOUDDST-13363