### PR TITLE
Tolerate missing v2s2

### DIFF
--- a/pubtools/_quay/exceptions.py
+++ b/pubtools/_quay/exceptions.py
@@ -20,3 +20,7 @@ class InvalidRepository(Exception):
 
 class SigningError(Exception):
     """Occurs when there was an issue in the container signing process done by RADAS."""
+
+
+class ManifestNotFoundError(Exception):
+    """Occurs when manifest is not found on the server."""

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -617,21 +617,19 @@ class PushDocker:
                 v2_sch2_cache = {}
                 for tag in tags:
                     for mtype in missing_media_types:
-                        print(item, repo, tag, mtype)
                         if mtype == QuayClient.MANIFEST_V2S2_TYPE:
                             if repo not in v2_sch2_cache:
                                 try:
                                     v2_sch2_cache[repo] = self._fetch_digest(
                                         internal_repo, tag, mtype
                                     )
-                                # Tolarate missing v2ch2 manifest in the case repo is
-                                # no amd64 arch and has only manifest list and sch2v1
-                                except ManifestNotFoundError:
-                                    pass
-                                else:
                                     item.metadata["new_digests"].setdefault((repo, tag), {})[
                                         mtype
                                     ] = v2_sch2_cache[repo]
+                                # Tolarate missing v2ch2 manifest in the case repo has
+                                # no amd64 arch and has only manifest list and sch2v1
+                                except ManifestNotFoundError:
+                                    pass
                         # Fetch v2s1 only for amd64 image
                         elif item.metadata["arch"] in ["amd64", "x86_64"]:
                             item.metadata["new_digests"].setdefault((repo, tag), {})[


### PR DESCRIPTION
For single arch repositories which are not for amd64 manifest
v2sch2 can missing and only manifest list with v2ch1 present.
Method for fetching missing digests should tolerate this.
