### PR TITLE
Use real task ID for tag docker signing

### DIFF
--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -702,22 +702,6 @@ class OperatorSignatureHandler(SignatureHandler):
 class BasicSignatureHandler(SignatureHandler):
     """Class that handles signing claims which were constructed by user."""
 
-    def __init__(self, hub, target_settings, target_name):
-        """
-        Initialize.
-
-        NOTE: "task_id" is not needed for this workflow
-
-        Args:
-            hub (HubProxy):
-                Instance of XMLRPC pub-hub proxy.
-            target_settings (dict):
-                Target settings.
-            target_name (str):
-                Name of the target.
-        """
-        SignatureHandler.__init__(self, hub, "1", target_settings, target_name)
-
     def sign_claim_messages(self, claim_messages, remove_duplicates=True, filter_existing=True):
         """
         Sign claim messages that were provided by the user and upload them to Pyxis.

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -720,7 +720,9 @@ class TagDocker:
         PushDocker.check_repos_validity(self.push_items, self.hub, self.target_settings)
         # perform tag-docker-specific checks
         self.check_input_validity()
-        signature_handler = BasicSignatureHandler(self.hub, self.target_settings, self.target_name)
+        signature_handler = BasicSignatureHandler(
+            self.hub, self.task_id, self.target_settings, self.target_name
+        )
 
         with ContainerExecutor(
             self.target_settings["skopeo_image"],

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -879,22 +879,6 @@ def test_sign_task_index_image(
     assert claims == ["msg1", "msg2"]
 
 
-@mock.patch("pubtools._quay.signature_handler.QuayClient")
-def test_basic_signature_handler_init(mock_quay_client, target_settings):
-    hub = mock.MagicMock()
-    sig_handler = signature_handler.BasicSignatureHandler(hub, target_settings, "some-target")
-
-    assert sig_handler.hub == hub
-    assert sig_handler.task_id == "1"
-    assert sig_handler.dest_registries == ["some-registry1.com", "some-registry2.com"]
-    assert sig_handler.target_settings == target_settings
-    assert sig_handler.quay_host == "quay.io"
-    mock_quay_client.assert_not_called()
-
-    assert sig_handler.src_quay_client == mock_quay_client.return_value
-    mock_quay_client.assert_called_once_with("src-quay-user", "src-quay-pass", "quay.io")
-
-
 @mock.patch("pubtools._quay.signature_handler.SignatureHandler.upload_signatures_to_pyxis")
 @mock.patch("pubtools._quay.signature_handler.SignatureHandler.validate_radas_messages")
 @mock.patch("pubtools._quay.signature_handler.SignatureHandler.get_signatures_from_radas")
@@ -917,7 +901,7 @@ def test_sign_claim_messages(
     mock_filter_claim_msgs.return_value = ["msg2", "msg3"]
     mock_get_radas_signatures.return_value = ["sig2", "sig3"]
 
-    sig_handler = signature_handler.BasicSignatureHandler(hub, target_settings, "some-target")
+    sig_handler = signature_handler.BasicSignatureHandler(hub, "1", target_settings, "some-target")
     sig_handler.sign_claim_messages(["msg1", "msg2", "msg3", "msg4"])
     mock_remove_duplicate_claim_msgs.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])
     mock_filter_claim_msgs.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])
@@ -942,7 +926,7 @@ def test_sign_claim_messages_not_allowed(
 ):
     hub = mock.MagicMock()
     target_settings["docker_settings"]["docker_container_signing_enabled"] = False
-    sig_handler = signature_handler.BasicSignatureHandler(hub, target_settings, "some-target")
+    sig_handler = signature_handler.BasicSignatureHandler(hub, "1", target_settings, "some-target")
     sig_handler.sign_claim_messages(["msg1", "msg2", "msg3", "msg4"])
     mock_filter_claim_msgs.assert_not_called()
     mock_get_radas_signatures.assert_not_called()
@@ -971,7 +955,7 @@ def test_sign_claim_messages_no_signatures(
     mock_remove_duplicate_claim_msgs.return_value = ["msg1", "msg2", "msg3", "msg4"]
     mock_filter_claim_msgs.return_value = []
 
-    sig_handler = signature_handler.BasicSignatureHandler(hub, target_settings, "some-target")
+    sig_handler = signature_handler.BasicSignatureHandler(hub, "1", target_settings, "some-target")
     sig_handler.sign_claim_messages(["msg1", "msg2", "msg3", "msg4"])
     mock_remove_duplicate_claim_msgs.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])
     mock_filter_claim_msgs.assert_called_once_with(["msg1", "msg2", "msg3", "msg4"])

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -2019,7 +2019,7 @@ def test_run_add_noop(
         [tag_docker_push_item_add], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6", mock_container_executor.return_value.__enter__()
@@ -2077,7 +2077,7 @@ def test_run_add_tag_images(
         [tag_docker_push_item_add], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6", mock_container_executor.return_value.__enter__()
@@ -2147,7 +2147,7 @@ def test_run_add_merge_manifest_lists(
         [tag_docker_push_item_add], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     assert mock_tag_add_calculate_archs.call_count == 2
     assert mock_tag_add_calculate_archs.call_args_list[0] == mock.call(
         tag_docker_push_item_add, "v1.6", mock_container_executor.return_value.__enter__()
@@ -2217,7 +2217,7 @@ def test_run_remove_noop(
         [tag_docker_push_item_remove_src], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()
@@ -2275,7 +2275,7 @@ def test_run_remove_untag_image(
         [tag_docker_push_item_remove_src], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()
@@ -2338,7 +2338,7 @@ def test_run_remove_manifest_list_remove_archs(
         [tag_docker_push_item_remove_src], hub, target_settings
     )
     mock_check_input_validity.assert_called_once_with()
-    mock_basic_signature_handler.assert_called_once_with(hub, target_settings, "some-target")
+    mock_basic_signature_handler.assert_called_once_with(hub, "1", target_settings, "some-target")
     mock_tag_add_calculate_archs.assert_not_called()
     mock_copy_tag_sign_images.assert_not_called()
     mock_merge_manifest_lists_sign_images.assert_not_called()


### PR DESCRIPTION
Task ID is used to get task information and create message queue.
Use the real ID instead of 1 which may be a not existing task.

Refers to CLOUDDST-13848