### PR TITLE
Resolve bandit findings

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -104,3 +104,19 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update existing dependencies
+        run: sudo apt-get update -y
+      - name: Install system dependencies
+        run: sudo apt-get install -y libkrb5-dev
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install Tox
+        run: pip install tox
+      - name: Run Tox
+        run: tox -e py3-bandit -vv

--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -256,7 +256,7 @@ class RemoteExecutor(Executor):
                 key_filename=self.key_filename,
             )
 
-            ssh_in, out, err = client.exec_command(cmd)
+            ssh_in, out, err = client.exec_command(shlex_quote(cmd))  # nosec B601
             if stdin:
                 ssh_in.channel.send(stdin)
                 ssh_in.channel.shutdown_write()
@@ -384,7 +384,8 @@ class ContainerExecutor(Executor):
         Add a text file to the running container.
 
         The primary use-case is to store a secret which will be accessed from inside the container.
-        File will be stored in the path /tmp/<file_name>.
+        File will be stored in the path /var/<file_name>. The reason /var instead of /tmp is
+        that putting files with predefined names to /tmp is a security concern.
 
         Args:
             data (str):
@@ -403,7 +404,7 @@ class ContainerExecutor(Executor):
 
         data_stream.seek(0)
         success = self.client.put_archive(
-            container=self.container["Id"], path="/tmp", data=data_stream
+            container=self.container["Id"], path="/var", data=data_stream
         )
 
         if not success:
@@ -439,7 +440,7 @@ class ContainerExecutor(Executor):
         self._add_file(password, password_file)
 
         cmd_login = (
-            " sh -c 'cat /tmp/{1} | skopeo login --authfile $HOME/.docker/config.json"
+            " sh -c 'cat /var/{1} | skopeo login --authfile $HOME/.docker/config.json"
             ' -u "{0}" --password-stdin %s\'' % host
         ).format(shlex_quote(username), password_file)
         out, err = self._run_cmd(cmd_login)

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -458,7 +458,7 @@ def test_container_executor_add_file(
     mock_add_file.assert_called_once_with(mock_tarinfo.return_value, mock_bytesio2)
     mock_close.assert_called_once_with()
     mock_seek.assert_called_once_with(0)
-    mock_put_archive.assert_called_once_with(container="123", path="/tmp", data=mock_bytesio1)
+    mock_put_archive.assert_called_once_with(container="123", path="/var", data=mock_bytesio1)
 
 
 @mock.patch("pubtools._quay.command_executor.time.time")
@@ -543,7 +543,7 @@ def test_container_executor_skopeo_login(
         "skopeo login --get-login some-host", tolerate_err=True
     )
     assert mock_run_cmd.call_args_list[1] == mock.call(
-        " sh -c 'cat /tmp/skopeo_password.txt | skopeo login --authfile $HOME/.docker/config.json "
+        " sh -c 'cat /var/skopeo_password.txt | skopeo login --authfile $HOME/.docker/config.json "
         '-u "some-name" --password-stdin some-host\''
     )
     mock_add_file.assert_called_once_with("some-password", "skopeo_password.txt")
@@ -648,7 +648,7 @@ def test_container_executor_skopeo_login_fail(
         "skopeo login --get-login some-host", tolerate_err=True
     )
     assert mock_run_cmd.call_args_list[1] == mock.call(
-        " sh -c 'cat /tmp/skopeo_password.txt | skopeo login --authfile $HOME/.docker/config.json "
+        " sh -c 'cat /var/skopeo_password.txt | skopeo login --authfile $HOME/.docker/config.json "
         '-u "some-name" --password-stdin some-host\''
     )
     mock_add_file.assert_called_once_with("some-password", "skopeo_password.txt")

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -139,7 +139,7 @@ def test_get_pyxis_signature(
     fake_cert_key_paths,
 ):
     hub = mock.MagicMock()
-    temp_filename = "/tmp/pubtools_quay_get_signatures_ABC123"
+    temp_filename = "/var/pubtools_quay_get_signatures_ABC123"
     mock_tempfile.return_value.__enter__.return_value.name = temp_filename
 
     expected_data1 = [{"some": "data"}, {"other": "data"}]
@@ -166,7 +166,7 @@ def test_get_pyxis_signature(
             "--pyxis-ssl-keyfile",
             "/path/to/file.key",
             "--manifest-digest",
-            "@/tmp/pubtools_quay_get_signatures_ABC123",
+            "@/var/pubtools_quay_get_signatures_ABC123",
         ],
         {},
     )
@@ -181,7 +181,7 @@ def test_get_pyxis_signature(
             "--pyxis-ssl-keyfile",
             "/path/to/file.key",
             "--manifest-digest",
-            "@/tmp/pubtools_quay_get_signatures_ABC123",
+            "@/var/pubtools_quay_get_signatures_ABC123",
         ],
         {},
     )
@@ -300,7 +300,7 @@ def test_upload_signatures_pyxis(
     fake_cert_key_paths,
 ):
     hub = mock.MagicMock()
-    temp_filename = "/tmp/pubtools_quay_upload_signatures_ABC123"
+    temp_filename = "/var/pubtools_quay_upload_signatures_ABC123"
     mock_tempfile.return_value.__enter__.return_value.name = temp_filename
 
     sig_handler = signature_handler.SignatureHandler(hub, "1", target_settings, "some-target")
@@ -348,7 +348,7 @@ def test_upload_signatures_pyxis(
             "--pyxis-ssl-keyfile",
             "/path/to/file.key",
             "--signatures",
-            "@/tmp/pubtools_quay_upload_signatures_ABC123",
+            "@/var/pubtools_quay_upload_signatures_ABC123",
         ],
         {},
     )

--- a/tests/test_signature_remover.py
+++ b/tests/test_signature_remover.py
@@ -55,7 +55,7 @@ def test_get_signatures_from_pyxis(mock_run_entrypoint, mock_tempfile, mock_json
     expected_data2 = [{"some-other": "data"}]
     mock_run_entrypoint.side_effect = [iter(expected_data1), iter(expected_data2)]
 
-    temp_filename = "/tmp/pubtools_quay_get_signatures_ABC123"
+    temp_filename = "/var/pubtools_quay_get_signatures_ABC123"
     mock_tempfile.return_value.__enter__.return_value.name = temp_filename
 
     sig_remover = signature_remover.SignatureRemover()
@@ -82,7 +82,7 @@ def test_get_signatures_from_pyxis(mock_run_entrypoint, mock_tempfile, mock_json
             "--pyxis-ssl-keyfile",
             "some-keytab",
             "--manifest-digest",
-            "@/tmp/pubtools_quay_get_signatures_ABC123",
+            "@/var/pubtools_quay_get_signatures_ABC123",
         ],
         {},
     )
@@ -97,7 +97,7 @@ def test_get_signatures_from_pyxis(mock_run_entrypoint, mock_tempfile, mock_json
             "--pyxis-ssl-keyfile",
             "some-keytab",
             "--manifest-digest",
-            "@/tmp/pubtools_quay_get_signatures_ABC123",
+            "@/var/pubtools_quay_get_signatures_ABC123",
         ],
         {},
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,black,flake8,docs
+envlist = py27,py37,black,flake8,docs,py3-bandit
 skip_missing_interpreters = true
 
 [testenv]
@@ -50,6 +50,12 @@ deps =
     flake8-docstrings
 commands =
     flake8 pubtools tests
+
+[testenv:py3-bandit]
+deps=
+    bandit
+commands=
+    bandit -r . -ll --exclude './.tox'
 
 [flake8]
 ignore = D100,D104,W503


### PR DESCRIPTION
Two findings of note:
- Adding shlex.quote to paramiko commands. The finding was not resolved
  after adding it, so nosec comment was added.
- When uploading files to containers, changing the destination directory
  from /tmp to /var. While I don't believe that /tmp is a security risk
  for one-off containers, /var should also work for most images.

Refers to CLOUDDST-14671