### PR TITLE
Authenticator class to provide custom args for registry authentication

### DIFF
--- a/docs/source/quay_client.rst
+++ b/docs/source/quay_client.rst
@@ -17,5 +17,5 @@ Full Docker HTTP API reference can be found at https://docs.docker.com/registry/
    .. automethod:: upload_manifest
    .. automethod:: get_repository_tags
    .. automethod:: _request_quay
-   .. automethod:: _authenticate_quay
    .. automethod:: _parse_and_validate_image_url
+

--- a/tests/test_ml_merger.py
+++ b/tests/test_ml_merger.py
@@ -306,7 +306,7 @@ def test_merge_selected_architectures():
         assert created_ml == expected_ml
 
 
-@mock.patch("pubtools._quay.quay_client.QuayClient._authenticate_quay")
+@mock.patch("pubtools._quay.quay_client.RegistryAuthenticator.authenticate")
 def test_merge_selected_architectures_no_dest_manifest(mock_authenticate):
     merger = manifest_list_merger.ManifestListMerger(
         "quay.io/src/image:1",


### PR DESCRIPTION
In the case that registry doesn't provide all requires parameters for
authentications, Authenticator class can provide missing parameters