### PR TITLE
Verify bundles presence

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -706,7 +706,10 @@ class PushDocker:
                 operator_push_items, self.task_id, self.target_settings
             )
             existing_index_images = operator_pusher.get_existing_index_images(self.dest_quay_client)
-            iib_results = operator_pusher.build_index_images()
+            if operator_pusher.ensure_bundles_present():
+                iib_results = operator_pusher.build_index_images()
+            else:
+                iib_results = {}
             # Sign operator images
             successful_iib_results = dict(
                 [(key, val) for key, val in iib_results.items() if val["iib_result"]]
@@ -720,7 +723,7 @@ class PushDocker:
             if not any([x["iib_result"] for x in iib_results.values()]):
                 LOG.error("Push of all index images failed, running rollback.")
                 self.rollback(backup_tags, rollback_tags)
-                failed = True
+                sys.exit(1)
             if successful_iib_results != iib_results:
                 LOG.error("Push of some index images failed")
                 failed = True

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -1,6 +1,8 @@
 import argparse
+import base64
 import contextlib
 import functools
+import json
 import logging
 import os
 import pkg_resources
@@ -367,3 +369,24 @@ def parse_index_image(build_details):
     registry, namespace, repo = image_path.split("/")
 
     return (registry, namespace, repo)
+
+
+def get_basic_auth(host):
+    """
+    Look for container config file for username and password.
+
+    Args:
+        host (str):
+            Hostname of a container registry.
+    Returns ((str, str)):
+        Username, password of a registry.
+    """
+    home_dir = os.path.expanduser("~")
+    conf_file = os.path.join(home_dir, ".docker/config.json")
+    if os.path.isfile(conf_file):
+        with open(conf_file) as f:
+            config = json.load(f)
+        auth = config.get("auths", {}).get(host, {}).get("auth")
+        if auth:
+            return base64.b64decode(auth).decode().split(":")
+    return None, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -698,6 +698,8 @@ def target_settings():
         "skopeo_image": "registry.com/some/image:1",
         "skopeo_executor_username": "quay-executor-user",
         "skopeo_executor_password": "quay-executor-password",
+        "verify_bundle_tries": 2,
+        "verify_bundle_wait_time_increase": 1,
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ import pytest
 import requests_mock
 import requests
 import os
+import six
 
 from pubtools._quay import exceptions
 from pubtools._quay.utils import misc
@@ -162,3 +163,14 @@ def test_retry(mock_timestamp, mock_sleep):
     assert mock_sleep.call_args_list[0] == mock.call(0)
     assert mock_sleep.call_args_list[1] == mock.call(10)
     assert mock_sleep.call_args_list[2] == mock.call(20)
+
+
+@mock.patch(
+    "six.moves.builtins.open",
+    new_callable=mock.mock_open,
+    read_data='{"auths": {"registry": {"auth": "dXNlcjpwYXNz"}}}',
+)
+@mock.patch("os.path.isfile")
+def test_get_basic_auth(mock_isfile, mock_file):
+    mock_isfile.return_value = True
+    assert misc.get_basic_auth("registry") == ["user", "pass"]


### PR DESCRIPTION
Ensure bundles are reachable before requesting IIB. Skip building index image if timeout is reached. Skip removing old signatures if rollback happens.

Refers to CLOUDDST-15796