### PR TITLE
Use namespace from index image target settings

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -104,7 +104,7 @@ def task_iib_add_bundles(
     _, tag = build_details.index_image.split(":", 1)
     dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag=tag,
     )
@@ -140,14 +140,23 @@ def task_iib_add_bundles(
     )
     dest_image_stamp = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag="%s-%s" % (tag, index_stamp),
     )
 
     # Push image to Quay
+    # Copy target settings and override username and password for quay_operator_namespace
+    index_image_ts = target_settings.copy()
+    index_image_ts["dest_quay_user"] = index_image_ts.get(
+        "index_image_quay_user", index_image_ts["dest_quay_user"]
+    )
+    index_image_ts["dest_quay_password"] = index_image_ts.get(
+        "index_image_quay_password", index_image_ts["dest_quay_password"]
+    )
+
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
+        build_details.index_image, [dest_image], True, index_image_ts
     )
     # Permanent index image with proxy as a host must be used because skopeo cannot handle
     # login to two Quay namespaces at the same time
@@ -158,7 +167,7 @@ def task_iib_add_bundles(
         tag=build_details.build_tags[0],
     )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, index_image_ts
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -209,7 +218,7 @@ def task_iib_remove_operators(
     _, tag = build_details.index_image.split(":", 1)
     dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag=tag,
     )
@@ -246,14 +255,23 @@ def task_iib_remove_operators(
     )
     dest_image_stamp = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag="%s-%s" % (tag, index_stamp),
     )
 
     # Push image to Quay
+    # Copy target settings and override username and password for quay_operator_namespace
+    index_image_ts = target_settings.copy()
+    index_image_ts["dest_quay_user"] = index_image_ts.get(
+        "index_image_quay_user", index_image_ts["dest_quay_user"]
+    )
+    index_image_ts["dest_quay_password"] = index_image_ts.get(
+        "index_image_quay_password", index_image_ts["dest_quay_password"]
+    )
+
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
+        build_details.index_image, [dest_image], True, index_image_ts
     )
     # Permanent index image with proxy as a host must be used because skopeo cannot handle
     # login to two Quay namespaces at the same time
@@ -264,7 +282,7 @@ def task_iib_remove_operators(
         tag=build_details.build_tags[0],
     )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, index_image_ts
     )
 
     signature_ids = [s["_id"] for s in old_signatures]
@@ -313,7 +331,7 @@ def task_iib_build_from_scratch(
 
     dest_image = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag=index_image_tag,
     )
@@ -329,7 +347,7 @@ def task_iib_build_from_scratch(
     index_stamp = timestamp()
     dest_image_stamp = image_schema_tag.format(
         host=target_settings.get("quay_host", "quay.io").rstrip("/"),
-        namespace=target_settings["quay_namespace"],
+        namespace=target_settings.get("quay_operator_namespace", target_settings["quay_namespace"]),
         repo=get_internal_container_repo_name(target_settings["quay_operator_repository"]),
         tag="%s-%s" % (index_image_tag, index_stamp),
     )
@@ -343,8 +361,15 @@ def task_iib_build_from_scratch(
     )
 
     # Push image to Quay
+    index_image_ts = target_settings.copy()
+    index_image_ts["dest_quay_user"] = index_image_ts.get(
+        "index_image_quay_user", index_image_ts["dest_quay_user"]
+    )
+    index_image_ts["dest_quay_password"] = index_image_ts.get(
+        "index_image_quay_password", index_image_ts["dest_quay_password"]
+    )
     ContainerImagePusher.run_tag_images(
-        build_details.index_image, [dest_image], True, target_settings
+        build_details.index_image, [dest_image], True, index_image_ts
     )
     # Permanent index image with proxy as a host must be used because skopeo cannot handle
     # login to two Quay namespaces at the same time
@@ -355,7 +380,7 @@ def task_iib_build_from_scratch(
         tag=build_details.build_tags[0],
     )
     ContainerImagePusher.run_tag_images(
-        permanent_index_image_proxy, [dest_image_stamp], True, target_settings
+        permanent_index_image_proxy, [dest_image_stamp], True, index_image_ts
     )
 
 

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -523,7 +523,7 @@ class OperatorPusher:
         image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
         index_image_repo = image_schema.format(
             host=self.quay_host,
-            namespace=self.target_settings["quay_namespace"],
+            namespace=self.target_settings["quay_operator_repository"].split("/")[-1],
             repo=get_internal_container_repo_name(self.target_settings["quay_operator_repository"]),
         )
 
@@ -546,6 +546,14 @@ class OperatorPusher:
                 dest_image = "{0}:{1}".format(index_image_repo, results["hotfix_tag"])
             # We don't use permanent index image here because we always want to overwrite
             # production tags with the latest index image (in case of parallel pushes)
+            index_image_ts = self.target_settings.copy()
+            index_image_ts["dest_quay_user"] = index_image_ts.get(
+                "index_image_quay_user", index_image_ts["dest_quay_user"]
+            )
+            index_image_ts["dest_quay_password"] = index_image_ts.get(
+                "index_image_quay_password", index_image_ts["dest_quay_password"]
+            )
+
             ContainerImagePusher.run_tag_images(
                 build_details.index_image, [dest_image], True, self.target_settings
             )

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -376,7 +376,11 @@ class OperatorPusher:
             self.target_settings["quay_operator_repository"]
         )
         index_image_repo = image_schema.format(
-            host=self.quay_host, namespace=self.target_settings["quay_namespace"], repo=iib_repo
+            host=self.quay_host,
+            namespace=self.target_settings.get(
+                "quay_operator_namespace", self.target_settings["quay_namespace"]
+            ),
+            repo=iib_repo,
         )
         current_index_images = []
 
@@ -523,7 +527,9 @@ class OperatorPusher:
         image_schema_tag = "{host}/{namespace}/{repo}:{tag}"
         index_image_repo = image_schema.format(
             host=self.quay_host,
-            namespace=self.target_settings["quay_operator_repository"].split("/")[-1],
+            namespace=self.target_settings.get(
+                "quay_operator_namespace", self.target_settings["quay_namespace"]
+            ),
             repo=get_internal_container_repo_name(self.target_settings["quay_operator_repository"]),
         )
 
@@ -555,10 +561,10 @@ class OperatorPusher:
             )
 
             ContainerImagePusher.run_tag_images(
-                build_details.index_image, [dest_image], True, self.target_settings
+                build_details.index_image, [dest_image], True, index_image_ts
             )
             if tag_suffix:
                 dest_image = "{0}:{1}-{2}".format(index_image_repo, tag, tag_suffix)
                 ContainerImagePusher.run_tag_images(
-                    permanent_index_image, [dest_image], True, self.target_settings
+                    permanent_index_image, [dest_image], True, index_image_ts
                 )

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -55,6 +55,7 @@ class PushDocker:
         self.quay_host = self.target_settings.get("quay_host", "quay.io").rstrip("/")
 
         self._dest_quay_client = None
+        self._dest_operator_quay_client = None
         self._dest_quay_api_client = None
 
     @property
@@ -67,6 +68,21 @@ class PushDocker:
                 self.quay_host,
             )
         return self._dest_quay_client
+
+    @property
+    def dest_operator_quay_client(self):
+        """Create and access QuayClient for dest image."""
+        if self._dest_operator_quay_client is None:
+            self._dest_operator_quay_client = QuayClient(
+                self.target_settings.get(
+                    "index_image_quay_user", self.target_settings["dest_quay_user"]
+                ),
+                self.target_settings.get(
+                    "index_image_quay_password", self.target_settings["dest_quay_password"]
+                ),
+                self.quay_host,
+            )
+        return self._dest_operator_quay_client
 
     @property
     def dest_quay_api_client(self):
@@ -705,7 +721,9 @@ class PushDocker:
             operator_pusher = OperatorPusher(
                 operator_push_items, self.task_id, self.target_settings
             )
-            existing_index_images = operator_pusher.get_existing_index_images(self.dest_quay_client)
+            existing_index_images = operator_pusher.get_existing_index_images(
+                self.dest_operator_quay_client
+            )
             if operator_pusher.ensure_bundles_present():
                 iib_results = operator_pusher.build_index_images()
             else:

--- a/tests/test_iib_operations.py
+++ b/tests/test_iib_operations.py
@@ -132,6 +132,110 @@ def test_task_iib_add_bundles(
 @mock.patch("pubtools._quay.iib_operations.SignatureRemover")
 @mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
+def test_task_iib_add_bundles_operator_ns(
+    mock_timestamp,
+    mock_verify_target_settings,
+    mock_iib_add_bundles,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    mock_signature_remover,
+    target_settings,
+    fake_cert_key_paths,
+):
+    target_settings["quay_operator_namespace"] = "operator-ns"
+
+    mock_timestamp.return_value = "timestamp"
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/iib@sha256:a1a1a1",
+        ["8-1"],
+    )
+    mock_iib_add_bundles.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_sign_task_index_image.return_value = [{"claim": "value1"}, {"claim": "value2"}]
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_get_index_image_signatures = mock.MagicMock()
+    mock_get_index_image_signatures.return_value = [
+        {"signature": "value1", "_id": "1"},
+        {"signature": "value2", "_id": "2"},
+    ]
+    mock_signature_remover.return_value.get_index_image_signatures = mock_get_index_image_signatures
+
+    mock_remove_signatures_from_pyxis = mock.MagicMock()
+    mock_signature_remover.return_value.remove_signatures_from_pyxis = (
+        mock_remove_signatures_from_pyxis
+    )
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_add_bundles(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "some-registry.com/redhat-namespace/new-index-image:5",
+        ["bundle3", "bundle4"],
+        ["some-key"],
+        mock_hub,
+        "1",
+        target_settings,
+        "some-target",
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_add_bundles.assert_called_once_with(
+        bundles=["bundle1", "bundle2"],
+        archs=["arch1", "arch2"],
+        index_image="some-registry.com/redhat-namespace/new-index-image:5",
+        deprecation_list=["bundle3", "bundle4"],
+        build_tags=["5-1"],
+        target_settings=target_settings,
+    )
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        [
+            "quay.io/operator-ns/operators----index-image:8",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "some-registry.com/iib-namespace/iib:8-1",
+        [
+            "quay.io/operator-ns/operators----index-image:8-timestamp",
+        ],
+        True,
+        target_settings,
+    )
+
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
+    mock_sign_task_index_image.assert_called_once_with(
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["8", "8-timestamp"]
+    )
+
+    mock_signature_remover.assert_called_once_with(
+        quay_api_token="dest-quay-token", quay_user="dest-quay-user", quay_password="dest-quay-pass"
+    )
+    mock_get_index_image_signatures.assert_called_once_with(
+        "quay.io/operator-ns/operators----index-image:8",
+        [{"claim": "value1"}, {"claim": "value2"}],
+        "pyxis-url.com",
+        "/path/to/file.crt",
+        "/path/to/file.key",
+    )
+    mock_remove_signatures_from_pyxis.assert_called_once_with(
+        ["1", "2"], "pyxis-url.com", "/path/to/file.crt", "/path/to/file.key"
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.SignatureRemover")
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_remove_operators")
 @mock.patch("pubtools._quay.iib_operations.verify_target_settings")
 @mock.patch("pubtools._quay.iib_operations.timestamp")
@@ -228,6 +332,107 @@ def test_task_iib_remove_operators(
     )
 
 
+@mock.patch("pubtools._quay.iib_operations.SignatureRemover")
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_remove_operators")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
+def test_task_iib_remove_operators_operator_ns(
+    mock_timestamp,
+    mock_verify_target_settings,
+    mock_iib_remove_operators,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    mock_signature_remover,
+    target_settings,
+    fake_cert_key_paths,
+):
+    target_settings["quay_operator_namespace"] = "operator-ns"
+
+    mock_timestamp.return_value = "timestamp"
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/iib@sha256:a1a1a1",
+        ["8-1"],
+    )
+    mock_iib_remove_operators.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_sign_task_index_image.return_value = [{"claim": "value1"}, {"claim": "value2"}]
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_get_index_image_signatures = mock.MagicMock()
+    mock_get_index_image_signatures.return_value = [
+        {"signature": "value1", "_id": "1"},
+        {"signature": "value2", "_id": "2"},
+    ]
+    mock_signature_remover.return_value.get_index_image_signatures = mock_get_index_image_signatures
+
+    mock_remove_signatures_from_pyxis = mock.MagicMock()
+    mock_signature_remover.return_value.remove_signatures_from_pyxis = (
+        mock_remove_signatures_from_pyxis
+    )
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_remove_operators(
+        ["operator1", "operator2"],
+        ["arch1", "arch2"],
+        "some-registry.com/redhat-namespace/new-index-image:5",
+        ["some-key"],
+        mock_hub,
+        "1",
+        target_settings,
+        "some-target",
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_remove_operators.assert_called_once_with(
+        operators=["operator1", "operator2"],
+        archs=["arch1", "arch2"],
+        index_image="some-registry.com/redhat-namespace/new-index-image:5",
+        build_tags=["5-1"],
+        target_settings=target_settings,
+    )
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        [
+            "quay.io/operator-ns/operators----index-image:8",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "some-registry.com/iib-namespace/iib:8-1",
+        [
+            "quay.io/operator-ns/operators----index-image:8-timestamp",
+        ],
+        True,
+        target_settings,
+    )
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
+    mock_sign_task_index_image.assert_called_once_with(
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["8", "8-timestamp"]
+    )
+
+    mock_signature_remover.assert_called_once_with(
+        quay_api_token="dest-quay-token", quay_user="dest-quay-user", quay_password="dest-quay-pass"
+    )
+    mock_get_index_image_signatures.assert_called_once_with(
+        "quay.io/operator-ns/operators----index-image:8",
+        [{"claim": "value1"}, {"claim": "value2"}],
+        "pyxis-url.com",
+        "/path/to/file.crt",
+        "/path/to/file.key",
+    )
+    mock_remove_signatures_from_pyxis.assert_called_once_with(
+        ["1", "2"], "pyxis-url.com", "/path/to/file.crt", "/path/to/file.key"
+    )
+
+
 @mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
 @mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
 @mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
@@ -284,6 +489,75 @@ def test_task_iib_build_from_scratch(
         "some-registry.com/iib-namespace/iib:8-1",
         [
             "quay.io/some-namespace/operators----index-image:12-timestamp",
+        ],
+        True,
+        target_settings,
+    )
+    mock_operator_signature_handler.assert_called_once_with(
+        mock_hub, "1", target_settings, "some-target"
+    )
+    mock_sign_task_index_image.assert_called_once_with(
+        ["some-key"], "quay.io/iib-namespace/iib:8-1", ["12", "12-timestamp"]
+    )
+
+
+@mock.patch("pubtools._quay.iib_operations.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.iib_operations.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.iib_operations.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.iib_operations.verify_target_settings")
+@mock.patch("pubtools._quay.iib_operations.timestamp")
+def test_task_iib_build_from_scratch_operator_ns(
+    mock_timestamp,
+    mock_verify_target_settings,
+    mock_iib_add_bundles,
+    mock_run_tag_images,
+    mock_operator_signature_handler,
+    target_settings,
+):
+    target_settings["quay_operator_namespace"] = "operator-ns"
+    mock_timestamp.return_value = "timestamp"
+    build_details = IIBRes(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        "some-registry.com/iib-namespace/iib@sha256:a1a1a1",
+        ["8-1"],
+    )
+    mock_iib_add_bundles.return_value = build_details
+
+    mock_sign_task_index_image = mock.MagicMock()
+    mock_operator_signature_handler.return_value.sign_task_index_image = mock_sign_task_index_image
+
+    mock_hub = mock.MagicMock()
+    iib_operations.task_iib_build_from_scratch(
+        ["bundle1", "bundle2"],
+        ["arch1", "arch2"],
+        "12",
+        ["some-key"],
+        mock_hub,
+        "1",
+        target_settings,
+        "some-target",
+    )
+
+    mock_verify_target_settings.assert_called_once_with(target_settings)
+    mock_iib_add_bundles.assert_called_once_with(
+        bundles=["bundle1", "bundle2"],
+        archs=["arch1", "arch2"],
+        build_tags=["12-1"],
+        target_settings=target_settings,
+    )
+    assert mock_run_tag_images.call_count == 2
+    assert mock_run_tag_images.call_args_list[0] == mock.call(
+        "some-registry.com/iib-namespace/new-index-image:8",
+        [
+            "quay.io/operator-ns/operators----index-image:12",
+        ],
+        True,
+        target_settings,
+    )
+    assert mock_run_tag_images.call_args_list[1] == mock.call(
+        "some-registry.com/iib-namespace/iib:8-1",
+        [
+            "quay.io/operator-ns/operators----index-image:12-timestamp",
         ],
         True,
         target_settings,

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -401,7 +401,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/index-image/operators----index-image:5"],
+                ["quay.io/some-namespace/operators----index-image:5"],
                 True,
                 target_settings,
             )
@@ -411,7 +411,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:6",
-                ["quay.io/index-image/operators----index-image:6"],
+                ["quay.io/some-namespace/operators----index-image:6"],
                 True,
                 target_settings,
             )
@@ -421,7 +421,89 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/index-image/operators----index-image:7"],
+                ["quay.io/some-namespace/operators----index-image:7"],
+                True,
+                target_settings,
+            )
+        ]
+    )
+
+
+@mock.patch("pubtools._quay.operator_pusher.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.operator_pusher.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+@mock.patch("pubtools._quay.operator_pusher.OperatorPusher.get_deprecation_list")
+def test_push_operators_extra_ns(
+    mock_get_deprecation_list,
+    mock_run_entrypoint,
+    mock_add_bundles,
+    mock_run_tag_images,
+    target_settings,
+    operator_push_item_ok,
+    operator_push_item_different_version,
+    fake_cert_key_paths,
+):
+    """Test if extra namespace is used in tagging when is set in target settings"""
+
+    target_settings["quay_operator_namespace"] = "quay-operator-ns"
+    mock_get_deprecation_list.side_effect = [["bundle1", "bundle2"], ["bundle3"], []]
+
+    mock_run_entrypoint.side_effect = [
+        [{"ocp_version": "4.5"}, {"ocp_version": "4.6"}, {"ocp_version": "4.7"}],
+        [{"ocp_version": "4.7"}],
+    ]
+    iib_results = [
+        IIBRes(
+            "some-registry.com/ns/index-image:5",
+            "some-registry.com/ns/iib@sha256:a1a1",
+            ["v4.5-3"],
+        ),
+        IIBRes(
+            "some-registry.com/ns/index-image:6",
+            "some-registry.com/ns/iib@sha256:b2b2",
+            ["v4.6-3"],
+        ),
+        IIBRes(
+            "some-registry.com/ns/index-image:7",
+            "some-registry.com/ns/iib@sha256:c3c3",
+            ["v4.7-3"],
+        ),
+    ]
+    mock_add_bundles.side_effect = iib_results
+    pusher = operator_pusher.OperatorPusher(
+        [operator_push_item_ok, operator_push_item_different_version], "3", target_settings
+    )
+
+    results = pusher.build_index_images()
+
+    pusher.push_index_images(results)
+
+    assert mock_run_tag_images.call_count == 3
+    mock_run_tag_images.assert_has_calls(
+        [
+            mock.call(
+                "some-registry.com/ns/index-image:5",
+                ["quay.io/quay-operator-ns/operators----index-image:5"],
+                True,
+                target_settings,
+            )
+        ]
+    )
+    mock_run_tag_images.assert_has_calls(
+        [
+            mock.call(
+                "some-registry.com/ns/index-image:6",
+                ["quay.io/quay-operator-ns/operators----index-image:6"],
+                True,
+                target_settings,
+            )
+        ]
+    )
+    mock_run_tag_images.assert_has_calls(
+        [
+            mock.call(
+                "some-registry.com/ns/index-image:7",
+                ["quay.io/quay-operator-ns/operators----index-image:7"],
                 True,
                 target_settings,
             )
@@ -524,7 +606,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/index-image/operators----index-image:5"],
+                ["quay.io/some-namespace/operators----index-image:5"],
                 True,
                 target_settings,
             )
@@ -534,7 +616,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/index-image/operators----index-image:7"],
+                ["quay.io/some-namespace/operators----index-image:7"],
                 True,
                 target_settings,
             )
@@ -621,7 +703,7 @@ def test_push_operators_hotfix(
         [
             mock.call(
                 "some-registry.com/index/image:5",
-                ["quay.io/index-image/operators----index-image:v4.5-test-hotfix-1234-4567"],
+                ["quay.io/some-namespace/operators----index-image:v4.5-test-hotfix-1234-4567"],
                 True,
                 target_settings,
             )
@@ -631,7 +713,7 @@ def test_push_operators_hotfix(
         [
             mock.call(
                 "some-registry.com/index/image:6",
-                ["quay.io/index-image/operators----index-image:v4.6-test-hotfix-1234-4567"],
+                ["quay.io/some-namespace/operators----index-image:v4.6-test-hotfix-1234-4567"],
                 True,
                 target_settings,
             )

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -401,7 +401,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/some-namespace/operators----index-image:5"],
+                ["quay.io/index-image/operators----index-image:5"],
                 True,
                 target_settings,
             )
@@ -411,7 +411,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:6",
-                ["quay.io/some-namespace/operators----index-image:6"],
+                ["quay.io/index-image/operators----index-image:6"],
                 True,
                 target_settings,
             )
@@ -421,7 +421,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/some-namespace/operators----index-image:7"],
+                ["quay.io/index-image/operators----index-image:7"],
                 True,
                 target_settings,
             )
@@ -524,7 +524,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/some-namespace/operators----index-image:5"],
+                ["quay.io/index-image/operators----index-image:5"],
                 True,
                 target_settings,
             )
@@ -534,7 +534,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/some-namespace/operators----index-image:7"],
+                ["quay.io/index-image/operators----index-image:7"],
                 True,
                 target_settings,
             )
@@ -621,7 +621,7 @@ def test_push_operators_hotfix(
         [
             mock.call(
                 "some-registry.com/index/image:5",
-                ["quay.io/some-namespace/operators----index-image:v4.5-test-hotfix-1234-4567"],
+                ["quay.io/index-image/operators----index-image:v4.5-test-hotfix-1234-4567"],
                 True,
                 target_settings,
             )
@@ -631,7 +631,7 @@ def test_push_operators_hotfix(
         [
             mock.call(
                 "some-registry.com/index/image:6",
-                ["quay.io/some-namespace/operators----index-image:v4.6-test-hotfix-1234-4567"],
+                ["quay.io/index-image/operators----index-image:v4.6-test-hotfix-1234-4567"],
                 True,
                 target_settings,
             )


### PR DESCRIPTION
Use image-image target settings to extract namespace where index image should be pushed to. Also added new target settings for specifying username and password were introduced

- "index_image_quay_user"
- "index_image_quay_password"

This change is needed due to fact index image is pushed to different namespace then rest of the containers. In the future there should be unification so changes in this commit should be seen as temporary