### PR TITLE
Unpin requests-mock version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 mock
-requests-mock==1.8.0
+requests-mock
 pytest
 pytest-pylint
 pytest-cov


### PR DESCRIPTION
The `requests-mock` dependency was previously pinned to version `1.8.0` due to bugs with Python2. Now that support for py2 has been dropped, we can go back to using the latest versions.