### PR TITLE
Fix race condition in parallel container pushes

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -47,23 +47,21 @@ class ContainerImagePusher:
     @property
     def src_quay_client(self):
         """Create and access QuayClient for source image."""
-        if self._src_quay_client is None:
-            self._src_quay_client = QuayClient(
-                self.target_settings["source_quay_user"],
-                self.target_settings["source_quay_password"],
-                self.target_settings.get("source_quay_host") or self.quay_host,
-            )
+        self._src_quay_client = QuayClient(
+            self.target_settings["source_quay_user"],
+            self.target_settings["source_quay_password"],
+            self.target_settings.get("source_quay_host") or self.quay_host,
+        )
         return self._src_quay_client
 
     @property
     def dest_quay_client(self):
         """Create and access QuayClient for dest image."""
-        if self._dest_quay_client is None:
-            self._dest_quay_client = QuayClient(
-                self.target_settings["dest_quay_user"],
-                self.target_settings["dest_quay_password"],
-                self.quay_host,
-            )
+        self._dest_quay_client = QuayClient(
+            self.target_settings["dest_quay_user"],
+            self.target_settings["dest_quay_password"],
+            self.quay_host,
+        )
         return self._dest_quay_client
 
     @classmethod


### PR DESCRIPTION
QuayClient was shared among parallel pushes. One push gets 401 when Bearer token in session is overwritten by another push. Create a new QuayClient for each push to avoid the conflict.

Refers to CLOUDDST-17492