### PR TITLE
Add removing outdated signatures into task_status.jsonl [CLOUDDST-17374]

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -449,6 +449,7 @@ class PushDocker:
                 if e.response.status_code != 404 and e.response.status_code != 401:
                     raise
 
+    @log_step("Remove outdated signatures")
     def remove_old_signatures(
         self,
         push_items,


### PR DESCRIPTION
Since removing outdated signatures took more than 30 minutes in some large OCP pushes before optimization[1]  , it'd better to add it to task_status.jsonl so that we can observe duration and duration change of this step.

[1] https://issues.redhat.com/browse/CLOUDDST-17373.