### PR TITLE
Pin bandit version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,3 +8,4 @@ pyrsistent==0.15.7;python_version<'3.0'
 pushcollector
 PyHamcrest
 python-qpid-proton==0.33.0;python_version<'3.0'
+bandit==1.7.5

--- a/tox.ini
+++ b/tox.ini
@@ -48,7 +48,7 @@ commands =
 
 [testenv:py3-bandit]
 deps=
-    bandit
+    -rrequirements-test.txt
 commands=
     bandit -r . -ll --exclude './.tox'
 


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to tox.ini.