### PR TITLE
Make executor configurable [CLOUDDST-12850]

### DIFF
--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -82,9 +82,7 @@ class Executor(object):
             )
         LOG.info("Logging in to Quay with provided credentials")
 
-        cmd_login = (
-            "skopeo login --authfile $HOME/.docker/config.json -u {0} --password-stdin %s" % host
-        ).format(quote(username))
+        cmd_login = ("skopeo login -u {0} --password-stdin %s" % host).format(quote(username))
         out, err = self._run_cmd(cmd_login, stdin=password)
 
         if "Login Succeeded" in out:
@@ -258,6 +256,8 @@ class RemoteExecutor(Executor):
                 key_filename=self.key_filename,
             )
 
+            if cmd.startswith("skopeo"):
+                cmd = cmd + " --authfile $HOME/.docker/config.json"
             ssh_in, out, err = client.exec_command(quote(cmd))  # nosec B601
             if stdin:
                 ssh_in.channel.send(stdin)

--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -92,7 +92,7 @@ class ContainerImagePusher:
             source_quay_host=target_settings.get("source_quay_host"),
             source_quay_user=target_settings.get("source_quay_user"),
             source_quay_password=target_settings.get("source_quay_password"),
-            container_exec=True,
+            container_exec=target_settings.get("container_exec", True),
             container_image=target_settings["skopeo_image"],
             docker_url=target_settings.get("docker_host") or "unix://var/run/docker.sock",
             docker_timeout=target_settings.get("docker_timeout"),

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -162,7 +162,7 @@ def test_remote_executor_run(mock_sshclient):
     mock_exec_command.return_value = (mock_in, mock_out, mock_err)
     mock_sshclient.return_value.exec_command = mock_exec_command
 
-    out, err = executor._run_cmd("pwd", stdin="input")
+    out, err = executor._run_cmd("skopeo", stdin="input")
 
     mock_load_host_keys.assert_called_once()
     assert mock_set_keys.call_count == 1
@@ -175,7 +175,7 @@ def test_remote_executor_run(mock_sshclient):
         port=22,
         key_filename="path/to/file.key",
     )
-    mock_exec_command.assert_called_once_with("pwd")
+    mock_exec_command.assert_called_once_with("'skopeo --authfile $HOME/.docker/config.json'")
     mock_send.assert_called_once_with("input")
     mock_shutdown_write.assert_called_once()
     mock_recv_exit_status.assert_called_once()
@@ -689,8 +689,7 @@ def test_skopeo_login_success(mock_run_cmd):
     assert mock_run_cmd.call_args_list == [
         mock.call("skopeo login --get-login quay_host", tolerate_err=True),
         mock.call(
-            "skopeo login --authfile $HOME/.docker/config.json -u quay_user "
-            "--password-stdin quay_host",
+            "skopeo login -u quay_user --password-stdin quay_host",
             stdin="quay_token",
         ),
     ]


### PR DESCRIPTION
Use local executor when container_exec is set to False in target settings. Remove authfile from local executor commands. The path is not writable in OpenShift pod which will specify a different path by REGISTRY_AUTH_FILE.