### PR TITLE
Remove less signatures [CLOUDDST-19242]

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -501,8 +501,8 @@ class PushDocker:
         """
         # if there are no rollback tags, it means content is repushed. And therefore nothing
         # should be removed.
-        if rollback_tags:
-            continue
+        if not rollback_tags:
+            return
         new_signatures = [(m["manifest_digest"], m["docker_reference"]) for m in claim_messages]
         outdated_signatures = []
 

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -687,9 +687,7 @@ class PushDocker:
         self.fetch_missing_push_items_digests(docker_push_items, self.target_settings)
 
         # sign missing images
-        manifest_claims += container_signature_handler.sign_container_images_new_digests(
-            docker_push_items
-        )
+        container_signature_handler.sign_container_images_new_digests(docker_push_items)
 
         failed = False
 

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -499,13 +499,14 @@ class PushDocker:
                 claim messages created for new index image(s)
 
         """
+        # if there are no rollback tags, it means content is repushed. And therefore nothing
+        # should be removed.
+        if rollback_tags:
+            continue
         new_signatures = [(m["manifest_digest"], m["docker_reference"]) for m in claim_messages]
         outdated_signatures = []
 
         for image_data, manifest in backup_tags.items():
-            # do not remove signatures for just pushed content in the case of a repush
-            if image_data in rollback_tags:
-                continue
             ext_repo = get_external_container_repo_name(image_data.repo.split("/")[1])
             if "manifests" in manifest:
                 for arch_manifest in manifest["manifests"]:

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -2190,6 +2190,7 @@ def test_remove_old_signatures_container_signatures(
     image_data = push_docker.PushDocker.ImageData(
         "reference/some-product----some-repo", "sometag", "some-digest", "other-digest"
     )
+    rollback_tags = [image_data]
     backup_tags[image_data] = "v2sch2-manifest"
     mock_target_settings = {
         "pyxis_server": "mock_pyxis_server",
@@ -2208,7 +2209,7 @@ def test_remove_old_signatures_container_signatures(
         [],
         {},
         backup_tags,
-        [],
+        rollback_tags,
         mock_container_signature_handler,
         mock_operator_signature_handler,
         mock_signature_remover,
@@ -2266,6 +2267,7 @@ def test_remove_old_signatures_operator_signatures(
         "reference/some-product----some-repo", "someversion", None, None
     )
     backup_tags[image_data] = {"digest": "some-digest"}
+    rollback_tags = [image_data]
     mock_target_settings = {
         "pyxis_server": "mock_pyxis_server",
         "iib_krb_principal": "mock_pyxis_principal",
@@ -2290,7 +2292,7 @@ def test_remove_old_signatures_operator_signatures(
             }
         },
         backup_tags,
-        [],
+        rollback_tags,
         mock_container_signature_handler,
         mock_operator_signature_handler,
         mock_signature_remover,
@@ -2382,5 +2384,5 @@ def test_remove_old_signatures_operator_signatures_repush(
         claim_messages,
     )
     mock_container_signature_handler.get_signatures_from_pyxis.assert_has_calls(
-        [mock.call([]), mock.call(["some-digest"])]
+        [mock.call([None]), mock.call(["some-digest"])]
     )


### PR DESCRIPTION
If signatures of a reference were partially uploaded due to an issue, re-push would add signatures of 'missing digests', but take the previously uploaded ones as outdated and remove them.

This patch excludes 'missing digests' signatures from new to avoid over removal. It's not ideal because unused signatures might not be removed in some cases. Until outdated signatures can be identified in a more accurate way, removing less is better than overly.