### PR TITLE
Trigger building index images in parallel [CLOUDDST-18034]

### DIFF
--- a/pubtools/_quay/models.py
+++ b/pubtools/_quay/models.py
@@ -1,0 +1,17 @@
+import dataclasses
+from typing import Dict, Any, List
+
+
+@dataclasses.dataclass
+class BuildIndexImageParam:
+    """Parameter data for building index image and part of data required by iib_results."""
+
+    bundles: str
+    index_image: str
+    deprecation_list: [str]
+    build_tags: List[str]
+    target_settings: Dict[str, Any]
+    tag: str
+    signing_keys: List[str]
+    is_hotfix: bool
+    hotfix_tag: str

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -2,7 +2,6 @@ import functools
 import logging
 import re
 import yaml
-from collections import namedtuple
 from concurrent import futures
 from concurrent.futures.thread import ThreadPoolExecutor
 
@@ -21,6 +20,7 @@ from .utils.misc import (
 )
 from .quay_client import QuayClient
 from .utils.misc import parse_index_image, pyxis_get_repo_metadata
+from .models import BuildIndexImageParam
 
 LOG = logging.getLogger("pubtools.quay")
 
@@ -527,20 +527,6 @@ class OperatorPusher:
         if failed_items:
             return {}
 
-        BuildIndexImageParam = namedtuple(
-            "BuildIndexImageParam",
-            [
-                "bundles",
-                "index_image",
-                "deprecation_list",
-                "build_tags",
-                "target_settings",
-                "tag",
-                "signing_keys",
-                "is_hotfix",
-                "hotfix_tag",
-            ],
-        )
         build_index_image_params = []
 
         for version, items in sorted(self.version_items_mapping.items()):
@@ -614,7 +600,7 @@ class OperatorPusher:
                     )
                 )
 
-        num_thread_build_index_images = self.target_settings.get("num_thread_build_index_images", 2)
+        num_thread_build_index_images = self.target_settings.get("num_thread_build_index_images", 5)
 
         with ThreadPoolExecutor(max_workers=num_thread_build_index_images) as executor:
             future_results = {


### PR DESCRIPTION
Now, IIB has improved the capacity to be able to handle more requests at the same time, so Pub can trigger building index images in parallel.

Refers to CLOUDDST-18034.