### PR TITLE
Make request session object per thread

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -47,21 +47,23 @@ class ContainerImagePusher:
     @property
     def src_quay_client(self):
         """Create and access QuayClient for source image."""
-        self._src_quay_client = QuayClient(
-            self.target_settings["source_quay_user"],
-            self.target_settings["source_quay_password"],
-            self.target_settings.get("source_quay_host") or self.quay_host,
-        )
+        if self._src_quay_client is None:
+            self._src_quay_client = QuayClient(
+                self.target_settings["source_quay_user"],
+                self.target_settings["source_quay_password"],
+                self.target_settings.get("source_quay_host") or self.quay_host,
+            )
         return self._src_quay_client
 
     @property
     def dest_quay_client(self):
         """Create and access QuayClient for dest image."""
-        self._dest_quay_client = QuayClient(
-            self.target_settings["dest_quay_user"],
-            self.target_settings["dest_quay_password"],
-            self.quay_host,
-        )
+        if self._dest_quay_client is None:
+            self._dest_quay_client = QuayClient(
+                self.target_settings["dest_quay_user"],
+                self.target_settings["dest_quay_password"],
+                self.quay_host,
+            )
         return self._dest_quay_client
 
     @classmethod

--- a/tests/test_quay_client.py
+++ b/tests/test_quay_client.py
@@ -15,6 +15,7 @@ def test_init(mock_session):
 
     assert client.username == "user"
     assert client.password == "pass"
+    assert client.session == mock_session.return_value
     mock_session.assert_called_once_with(api="docker", hostname="stage.quay.io")
 
 


### PR DESCRIPTION
Make QuaySession session object per thread when pushing images in parallel to avoid 401 error which are caused by shared session.

Refers to CLOUDDST-18029.

Note that, actually, a similar PR[1] was made by @emilyzheng to do the same thing before, and it works fine on prod. But I guess this new PR has a bit higher efficiency compared to the existing one[1] since request session is created per thread in the PR, while QuayClient/session is created per request in existing one[1].

[1] https://github.com/release-engineering/pubtools-quay/pull/163