### PR TITLE
When a command fails, print its error in multiple lines

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,7 +3,7 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py37:
+  py311:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,11 +14,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37 -vv
+        run: tox -e py311 -vv
   black:
     runs-on: ubuntu-latest
     steps:
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -62,7 +62,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -78,11 +78,11 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
-        run: tox -e py37
+        run: tox -e py311
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.2
         with:
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: Install Tox
         run: pip install tox
       - name: Run Tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,black,flake8,docs,py3-bandit
+envlist = py311,black,flake8,docs,py3-bandit
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
When skopeo copy fails, the error message cannot be accessed because the log of the command output gets truncated. Since the command generates new line characters, use them to split the output and log each line separately.

Refers to CLOUDDST-19503