### PR TITLE
Added support for pre-release containers

### DIFF
--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -128,11 +128,16 @@ class ContainerImagePusher:
         for repo, tags in sorted(push_item.metadata["tags"].items()):
             internal_repo = get_internal_container_repo_name(repo)
             for tag in tags:
+                dst_tag = (
+                    f"{tag}.{push_item.metadata.get('com.redhat.pre-release')}"
+                    if push_item.metadata.get("com.redhat.pre-release")
+                    else f"{tag}"
+                )
                 dest_ref = image_schema.format(
                     host=self.quay_host,
                     namespace=namespace,
                     repo=internal_repo,
-                    tag=tag,
+                    tag=dst_tag,
                 )
                 dest_refs.append(dest_ref)
         return dest_refs

--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -128,16 +128,11 @@ class ContainerImagePusher:
         for repo, tags in sorted(push_item.metadata["tags"].items()):
             internal_repo = get_internal_container_repo_name(repo)
             for tag in tags:
-                dst_tag = (
-                    f"{tag}.{push_item.metadata.get('com.redhat.prerelease')}"
-                    if push_item.metadata.get("com.redhat.prerelease")
-                    else f"{tag}"
-                )
                 dest_ref = image_schema.format(
                     host=self.quay_host,
                     namespace=namespace,
                     repo=internal_repo,
-                    tag=dst_tag,
+                    tag=tag,
                 )
                 dest_refs.append(dest_ref)
         return dest_refs

--- a/pubtools/_quay/container_image_pusher.py
+++ b/pubtools/_quay/container_image_pusher.py
@@ -129,8 +129,8 @@ class ContainerImagePusher:
             internal_repo = get_internal_container_repo_name(repo)
             for tag in tags:
                 dst_tag = (
-                    f"{tag}.{push_item.metadata.get('com.redhat.pre-release')}"
-                    if push_item.metadata.get("com.redhat.pre-release")
+                    f"{tag}.{push_item.metadata.get('com.redhat.prerelease')}"
+                    if push_item.metadata.get("com.redhat.prerelease")
                     else f"{tag}"
                 )
                 dest_ref = image_schema.format(

--- a/pubtools/_quay/models.py
+++ b/pubtools/_quay/models.py
@@ -14,4 +14,4 @@ class BuildIndexImageParam:
     tag: str
     signing_keys: List[str]
     is_hotfix: bool
-    hotfix_tag: str
+    destination_tags: List[str]

--- a/pubtools/_quay/models.py
+++ b/pubtools/_quay/models.py
@@ -13,5 +13,4 @@ class BuildIndexImageParam:
     target_settings: Dict[str, Any]
     tag: str
     signing_keys: List[str]
-    is_hotfix: bool
     destination_tags: List[str]

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -754,7 +754,11 @@ class OperatorPusher:
                 build_details.index_image, dest_images, True, index_image_ts
             )
             if tag_suffix:
-                dest_image = "{0}:{1}-{2}".format(index_image_repo, tag, tag_suffix)
+                _dest_images = []
+                for _dest_tag in results["destination_tags"]:
+                    _dest_images.append(
+                        "{0}:{1}-{2}".format(index_image_repo, _dest_tag, tag_suffix)
+                    )
                 ContainerImagePusher.run_tag_images(
-                    permanent_index_image, [dest_image], True, index_image_ts
+                    permanent_index_image, _dest_images, True, index_image_ts
                 )

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -549,20 +549,7 @@ class OperatorPusher:
                 item_groups[item.origin]["items"].append(item)
         else:
             for item in non_fbc_items:
-                if item.metadata.get("com.redhat.prerelease"):
-                    prerelease = item.metadata.get("com.redhat.prerelease")
-                    item_groups.setdefault(
-                        f"{version}.{item.origin}",
-                        {
-                            "items": [],
-                            "build_tags": [f"{version}.{item.origin}.{prerelease}"],
-                            "overwrite": False,
-                            "destination_tags": [f"{version}.{item.origin}.{prerelease}"],
-                        },
-                    )
-                    item_groups[f"{version}.{item.origin}"]["items"].append(item)
-                else:
-                    item_groups[version]["items"].append(item)
+                item_groups[version]["items"].append(item)
         return item_groups
 
     @log_step("Build index images")
@@ -612,7 +599,9 @@ class OperatorPusher:
             if is_prerelease and not is_advisory_source:
                 raise ValueError("Cannot push pre release without an advisory")
 
-            item_groups = self._create_item_groups_for_version(non_fbc_items, version, is_hotfix)
+            item_groups = self._create_item_groups_for_version(
+                non_fbc_items, version, is_hotfix, is_prerelease
+            )
 
             # Get deprecation list
             deprecation_list = self.get_deprecation_list(version)

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -535,7 +535,7 @@ class OperatorPusher:
     def _create_item_groups_for_version(
         self, non_fbc_items, version, is_hotfix=False, is_prerelease=False
     ):
-        """Iterate thought non fbc items and group those together based on version.
+        """Iterate thought non fbc items and group those together based on destination tag.
 
         Args:
             non_fbc_items: List[ContainerPushItem]
@@ -553,7 +553,6 @@ class OperatorPusher:
             version: {
                 "items": [],
                 "overwrite": True,
-                "build_tags": [],
                 "destination_tags": [version],
             }
         }
@@ -574,7 +573,6 @@ class OperatorPusher:
                     {
                         "items": [],
                         "overwrite": False,
-                        "build_tags": [],
                         "destination_tags": [dst_tag],
                     },
                 )
@@ -605,7 +603,6 @@ class OperatorPusher:
                 <target_tag>: {
                     "iib_result": (...) (object returned by iiblib)
                     "signing_keys": [...] (list of signing keys to be used for signing)
-                    "is_hotfix": (bool) flag indicating if group is for hotfix tag
                     "destination_tags": [...] (list of destination tags)
                 }
             }
@@ -648,7 +645,7 @@ class OperatorPusher:
                 index_image = "{image_repo}:{tag}".format(
                     image_repo=self.target_settings["iib_index_image"], tag=tag
                 )
-                build_tags = group_info["build_tags"]
+                build_tags = []
                 build_tags.append("{0}-{1}".format(index_image.split(":")[1], self.task_id))
 
                 bundles = [self.public_bundle_ref(i) for i in group_info["items"]]
@@ -673,10 +670,7 @@ class OperatorPusher:
                         target_settings=target_settings,
                         tag=tag,
                         signing_keys=signing_keys,
-                        is_hotfix=is_hotfix,
-                        destination_tags=group_info[
-                            "destination_tags"
-                        ],  # ="" if not is_hotfix else hotfix_tag,
+                        destination_tags=group_info["destination_tags"],
                     )
                 )
 
@@ -702,9 +696,7 @@ class OperatorPusher:
                 iib_results[param.tag] = {
                     "iib_result": build_details,
                     "signing_keys": param.signing_keys,
-                    "is_hotfix": param.is_hotfix,
                     "destination_tags": param.destination_tags,
-                    # "hotfix_tag": param.hotfix_tag,
                 }
 
         return iib_results

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -592,6 +592,8 @@ class OperatorPusher:
         This workflow is a part of push-docker operation.
         The workflow can be summarized as:
         - Use Pyxis to parse 'com.redhat.openshift.versions'
+        - Filter out push items which opted in to FBC and shouldn't be pushed
+        - Set extra attributes or push items are for prerelease or for hotfix
         - Get deprecation list for a given version (list of bundles to be deprecated)
         - Create mapping of which bundles should be pushed to which index image versions
         - Contact IIB to add the bundles to the index images with multiple threads

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -447,13 +447,12 @@ class OperatorPusher:
         return True
 
     def _get_fbc_opted_in_items(self):
-        """ Get items that are opted in for fbc.
+        """Get items that are opted in for fbc.
 
         An item needs to be targeted for repos with fbc_opt_in set to True and
         ocp versions needs to be higher than 4.12. Inconsistencies in versions
         (like support for both > 4.12 and <= 4.12) results  in item error.
         """
-
         repos_opted_in = {}
         items_opted_in = {}
         failed_items = {}
@@ -510,6 +509,7 @@ class OperatorPusher:
 
     def _get_non_fbc_items_for_version(self, items, version, items_opted_in):
         """Return non fbc items for given ocp version.
+
         Args:
             items: List[ContainerPushItem]
                 list of push items
@@ -520,7 +520,6 @@ class OperatorPusher:
         Returns List[ContainerPushItem]:
             list of items not opted in fbc
         """
-
         non_fbc_items = []
         osev_tuple = tuple([int(x) for x in version.replace("v", "").split(".")])
         for item in items:
@@ -537,6 +536,7 @@ class OperatorPusher:
         self, non_fbc_items, version, is_hotfix=False, is_prerelease=False
     ):
         """Iterate thought non fbc items and group those together based on version.
+
         Args:
             non_fbc_items: List[ContainerPushItem]
                 list of items not opted in fbc
@@ -549,7 +549,6 @@ class OperatorPusher:
         Returns Dict[str, Dict[str, Any]]:
             Dictionary of items grouped by ocp version
         """
-
         item_groups = {
             version: {
                 "items": [],

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -605,6 +605,8 @@ class OperatorPusher:
                 <target_tag>: {
                     "iib_result": (...) (object returned by iiblib)
                     "signing_keys": [...] (list of signing keys to be used for signing)
+                    "is_hotfix": (bool) flag indicating if group is for hotfix tag
+                    "destination_tags": [...] (list of destination tags)
                 }
             }
         """

--- a/pubtools/_quay/signature_handler.py
+++ b/pubtools/_quay/signature_handler.py
@@ -665,15 +665,11 @@ class OperatorSignatureHandler(SignatureHandler):
             )
             # Version acts as a tag of the index image
             # use hotfix tag if it exists
-            if iib_details["is_hotfix"]:
+            for dest_tag in iib_details["destination_tags"]:
                 claim_messages += self.construct_index_image_claim_messages(
                     permanent_index_image,
-                    [iib_details["hotfix_tag"], "%s-%s" % (version, tag_suffix)],
+                    [dest_tag, "%s-%s" % (dest_tag, tag_suffix)],
                     signing_keys,
-                )
-            else:
-                claim_messages += self.construct_index_image_claim_messages(
-                    permanent_index_image, [version, "%s-%s" % (version, tag_suffix)], signing_keys
                 )
 
         if not claim_messages:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,6 +388,45 @@ def operator_push_item_fbc_hotfix():
 
 
 @pytest.fixture
+def operator_push_item_pre_release():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="operator",
+        file_size=0,
+        file_info=None,
+        origin="RHBA-1234:4567",
+        repos=[],
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "com.redhat.openshift.versions": "v4.5",
+            "op_type": "bundle",
+            "build": {
+                "build_id": 123456,
+                "extra": {
+                    "image": {
+                        "media_types": ["application/vnd.docker.distribution.manifest.v2+json"]
+                    }
+                },
+            },
+            "destination": {"tags": {"repo": ["tag1", "tag2"]}},
+            "tags": {"repo": ["latest-test-tag", "1.0"]},
+            "v_r": "1.0",
+            "arch": "some-arch",
+            "com.redhat.pre-release": "pre-1.2",
+        },
+    )
+
+
+@pytest.fixture
 def operator_push_item_hotfix():
     return MockContainerPushItem(
         file_path="push_item_filepath",
@@ -892,6 +931,43 @@ def container_multiarch_push_item():
         state="NOTPUSHED",
         claims_signing_key="some-key",
         metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "destination": {"tags": {"repo": ["tag1"]}},
+            "tags": {"target/repo": ["latest-test-tag"]},
+            "v_r": "1.0",
+            "pull_url": "some-registry/src/repo:1",
+            "build": {
+                "extra": {
+                    "image": {
+                        "media_types": ["application/vnd.docker.distribution.manifest.v2+json"]
+                    }
+                }
+            },
+            "arch": "amd64",
+        },
+    )
+
+
+@pytest.fixture
+def container_multiarch_pre_release_push_item():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="docker",
+        file_size=0,
+        file_info=None,
+        origin="push_item_origin",
+        repos={"test_repo": []},
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "com.redhat.pre-release": "pre-1.2",
             "pull_data": {
                 "registry": "test-regitry",
                 "repo": "test-repo",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -421,7 +421,7 @@ def operator_push_item_pre_release():
             "tags": {"repo": ["latest-test-tag", "1.0"]},
             "v_r": "1.0",
             "arch": "some-arch",
-            "com.redhat.pre-release": "pre-1.2",
+            "com.redhat.prerelease": "pre-1.2",
         },
     )
 
@@ -500,6 +500,45 @@ def operator_push_item_hotfix_invalid_origin():
             "v_r": "1.0",
             "arch": "some-arch",
             "com.redhat.hotfix": "test-hotfix",
+        },
+    )
+
+
+@pytest.fixture
+def operator_push_item_prerelease_invalid_origin():
+    return MockContainerPushItem(
+        file_path="push_item_filepath",
+        file_name="push_item_filename",
+        file_type="operator",
+        file_size=0,
+        file_info=None,
+        origin="non-advisory-origin",
+        repos=[],
+        build="push_item_build",
+        checksums={},
+        state="NOTPUSHED",
+        claims_signing_key="some-key",
+        metadata={
+            "pull_data": {
+                "registry": "test-regitry",
+                "repo": "test-repo",
+                "tag": "test-tag",
+            },
+            "com.redhat.openshift.versions": "v4.5",
+            "op_type": "bundle",
+            "build": {
+                "build_id": 123456,
+                "extra": {
+                    "image": {
+                        "media_types": ["application/vnd.docker.distribution.manifest.v2+json"]
+                    }
+                },
+            },
+            "destination": {"tags": {"repo": ["tag1", "tag2"]}},
+            "tags": {"repo": ["latest-test-tag", "1.0"]},
+            "v_r": "1.0",
+            "arch": "some-arch",
+            "com.redhat.prerelease": "pre-1.2",
         },
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1006,7 +1006,7 @@ def container_multiarch_pre_release_push_item():
         state="NOTPUSHED",
         claims_signing_key="some-key",
         metadata={
-            "com.redhat.pre-release": "pre-1.2",
+            "com.redhat.prerelease": "pre-1.2",
             "pull_data": {
                 "registry": "test-regitry",
                 "repo": "test-repo",

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -774,12 +774,12 @@ def test_push_operators_prerelease(
         IIBRes(
             "some-registry.com/index/image:v4.5",
             "some-registry.com/index/image@sha256:a1a1",
-            ["v4.5-RHBA-1234-4567-pre-1.2"],
+            ["v4.5-1234-4567-pre-1.2"],
         ),
         IIBRes(
             "some-registry.com/index/image:v4.6",
             "some-registry.com/index/image@sha256:b2b2",
-            ["v4.6-RHBA-1234-4567.pre-1.2"],
+            ["v4.6-1234-4567.pre-1.2"],
         ),
     ]
     mock_add_bundles.side_effect = iib_results

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -363,19 +363,19 @@ def test_push_operators(
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.5"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.6"],
         },
         "v4.7": {
             "iib_result": iib_results[2],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.7"],
         },
     }
     assert mock_add_bundles.call_count == 3
@@ -408,7 +408,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/some-namespace/operators----index-image:5"],
+                ["quay.io/some-namespace/operators----index-image:v4.5"],
                 True,
                 target_settings,
             )
@@ -418,7 +418,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:6",
-                ["quay.io/some-namespace/operators----index-image:6"],
+                ["quay.io/some-namespace/operators----index-image:v4.6"],
                 True,
                 target_settings,
             )
@@ -428,7 +428,7 @@ def test_push_operators(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/some-namespace/operators----index-image:7"],
+                ["quay.io/some-namespace/operators----index-image:v4.7"],
                 True,
                 target_settings,
             )
@@ -498,7 +498,7 @@ def test_push_operators_extra_ns(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/quay-operator-ns/operators----index-image:5"],
+                ["quay.io/quay-operator-ns/operators----index-image:v4.5"],
                 True,
                 target_settings,
             )
@@ -508,7 +508,7 @@ def test_push_operators_extra_ns(
         [
             mock.call(
                 "some-registry.com/ns/index-image:6",
-                ["quay.io/quay-operator-ns/operators----index-image:6"],
+                ["quay.io/quay-operator-ns/operators----index-image:v4.6"],
                 True,
                 target_settings,
             )
@@ -518,7 +518,7 @@ def test_push_operators_extra_ns(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/quay-operator-ns/operators----index-image:7"],
+                ["quay.io/quay-operator-ns/operators----index-image:v4.7"],
                 True,
                 target_settings,
             )
@@ -584,19 +584,19 @@ def test_push_operators_not_all_successful(
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.5"],
         },
         "v4.6": {
             "iib_result": None,
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.6"],
         },
         "v4.7": {
             "iib_result": iib_results[2],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "hotfix_tag": "",
+            "destination_tags": ["v4.7"],
         },
     }
     assert mock_add_bundles.call_count == 3
@@ -629,7 +629,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:5",
-                ["quay.io/some-namespace/operators----index-image:5"],
+                ["quay.io/some-namespace/operators----index-image:v4.5"],
                 True,
                 target_settings,
             )
@@ -639,7 +639,7 @@ def test_push_operators_not_all_successful(
         [
             mock.call(
                 "some-registry.com/ns/index-image:7",
-                ["quay.io/some-namespace/operators----index-image:7"],
+                ["quay.io/some-namespace/operators----index-image:v4.7"],
                 True,
                 target_settings,
             )
@@ -699,13 +699,13 @@ def test_push_operators_hotfix(
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
             "is_hotfix": True,
-            "hotfix_tag": "v4.5-test-hotfix-1234-4567",
+            "destination_tags": ["v4.5-test-hotfix-1234-4567"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
             "is_hotfix": True,
-            "hotfix_tag": "v4.6-test-hotfix-1234-4567",
+            "destination_tags": ["v4.6-test-hotfix-1234-4567"],
         },
     }
     expected_target_settings = target_settings.copy()
@@ -716,14 +716,14 @@ def test_push_operators_hotfix(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5-3", "v4.5-test-hotfix-1234-4567"],
+        build_tags=["v4.5-3"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[1] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6-3", "v4.6-test-hotfix-1234-4567"],
+        build_tags=["v4.6-3"],
         target_settings=expected_target_settings,
     )
 
@@ -745,6 +745,111 @@ def test_push_operators_hotfix(
             mock.call(
                 "some-registry.com/index/image:6",
                 ["quay.io/some-namespace/operators----index-image:v4.6-test-hotfix-1234-4567"],
+                True,
+                target_settings,
+            )
+        ]
+    )
+
+
+@mock.patch("pubtools._quay.operator_pusher.ContainerImagePusher.run_tag_images")
+@mock.patch("pubtools._quay.operator_pusher.OperatorPusher.iib_add_bundles")
+@mock.patch("pubtools._quay.operator_pusher.run_entrypoint")
+@mock.patch("pubtools._quay.operator_pusher.OperatorPusher.get_deprecation_list")
+@mock.patch("pubtools._quay.operator_pusher.pyxis_get_repo_metadata")
+def test_push_operators_pre_release(
+    mock_get_repo_metadata,
+    mock_get_deprecation_list,
+    mock_run_entrypoint,
+    mock_add_bundles,
+    mock_run_tag_images,
+    target_settings,
+    operator_push_item_pre_release,
+    fake_cert_key_paths,
+):
+    mock_get_repo_metadata.side_effect = [
+        {"fbc_opt_in": False},
+        {"fbc_opt_in": False},
+        {"fbc_opt_in": False},
+    ]
+
+    mock_get_deprecation_list.side_effect = [["bundle1", "bundle2"], ["bundle3"]]
+
+    mock_run_entrypoint.side_effect = [
+        [{"ocp_version": "4.5"}, {"ocp_version": "4.6"}],
+    ]
+    iib_results = [
+        IIBRes(
+            "some-registry.com/index/image:v4.5",
+            "some-registry.com/index/image@sha256:a1a1",
+            ["v4.5-pre-1.2"],
+        ),
+        IIBRes(
+            "some-registry.com/index/image:v4.6",
+            "some-registry.com/index/image@sha256:b2b2",
+            ["v4.6-pre-1.2"],
+        ),
+    ]
+    mock_add_bundles.side_effect = iib_results
+    pusher = operator_pusher.OperatorPusher([operator_push_item_pre_release], "3", target_settings)
+
+    results = pusher.build_index_images()
+
+    assert mock_get_deprecation_list.call_count == 2
+    assert mock_get_deprecation_list.call_args_list[0] == mock.call("v4.5")
+    assert mock_get_deprecation_list.call_args_list[1] == mock.call("v4.6")
+
+    assert results == {
+        "v4.5": {
+            "iib_result": iib_results[0],
+            "signing_keys": ["some-key"],
+            "is_hotfix": False,
+            "destination_tags": ["v4.5.pre-1.2"],
+        },
+        "v4.6": {
+            "iib_result": iib_results[1],
+            "signing_keys": ["some-key"],
+            "is_hotfix": False,
+            "destination_tags": ["v4.6.pre-1.2"],
+        },
+    }
+    expected_target_settings = target_settings.copy()
+    expected_target_settings["iib_overwrite_from_index"] = False
+    expected_target_settings["iib_overwrite_from_index_token"] = ""
+    assert mock_add_bundles.call_count == 2
+    assert mock_add_bundles.call_args_list[0] == mock.call(
+        bundles=["some-registry1.com/repo:1.0"],
+        index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
+        deprecation_list=["bundle1", "bundle2"],
+        build_tags=["v4.5.pre-1.2", "v4.5-3"],
+        target_settings=expected_target_settings,
+    )
+    assert mock_add_bundles.call_args_list[1] == mock.call(
+        bundles=["some-registry1.com/repo:1.0"],
+        index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
+        deprecation_list=["bundle3"],
+        build_tags=["v4.6.pre-1.2", "v4.6-3"],
+        target_settings=expected_target_settings,
+    )
+
+    pusher.push_index_images(results)
+
+    assert mock_run_tag_images.call_count == 2
+    mock_run_tag_images.assert_has_calls(
+        [
+            mock.call(
+                "some-registry.com/index/image:v4.5",
+                ["quay.io/some-namespace/operators----index-image:v4.5.pre-1.2"],
+                True,
+                target_settings,
+            )
+        ]
+    )
+    mock_run_tag_images.assert_has_calls(
+        [
+            mock.call(
+                "some-registry.com/index/image:v4.6",
+                ["quay.io/some-namespace/operators----index-image:v4.6.pre-1.2"],
                 True,
                 target_settings,
             )
@@ -1028,13 +1133,13 @@ def test_push_operators_fbc_opted_in(
 
     assert results == {
         "v4.6": {
-            "hotfix_tag": "",
+            "destination_tags": ["v4.6"],
             "iib_result": iib_results[1],
             "is_hotfix": False,
             "signing_keys": ["some-key"],
         },
         "v4.12": {
-            "hotfix_tag": "",
+            "destination_tags": ["v4.12"],
             "iib_result": iib_results[0],
             "is_hotfix": False,
             "signing_keys": ["some-key"],

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -362,19 +362,16 @@ def test_push_operators(
         "v4.5": {
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.5"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.6"],
         },
         "v4.7": {
             "iib_result": iib_results[2],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.7"],
         },
     }
@@ -583,19 +580,16 @@ def test_push_operators_not_all_successful(
         "v4.5": {
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.5"],
         },
         "v4.6": {
             "iib_result": None,
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.6"],
         },
         "v4.7": {
             "iib_result": iib_results[2],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.7"],
         },
     }
@@ -698,13 +692,11 @@ def test_push_operators_hotfix(
         "v4.5": {
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
-            "is_hotfix": True,
             "destination_tags": ["v4.5-test-hotfix-1234-4567"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
-            "is_hotfix": True,
             "destination_tags": ["v4.6-test-hotfix-1234-4567"],
         },
     }
@@ -803,13 +795,11 @@ def test_push_operators_prerelease(
         "v4.5": {
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.5-pre-1.2-1234-4567"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
-            "is_hotfix": False,
             "destination_tags": ["v4.6-pre-1.2-1234-4567"],
         },
     }
@@ -1183,13 +1173,11 @@ def test_push_operators_fbc_opted_in(
         "v4.6": {
             "destination_tags": ["v4.6"],
             "iib_result": iib_results[1],
-            "is_hotfix": False,
             "signing_keys": ["some-key"],
         },
         "v4.12": {
             "destination_tags": ["v4.12"],
             "iib_result": iib_results[0],
-            "is_hotfix": False,
             "signing_keys": ["some-key"],
         },
     }

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -782,12 +782,12 @@ def test_push_operators_prerelease(
         IIBRes(
             "some-registry.com/index/image:v4.5",
             "some-registry.com/index/image@sha256:a1a1",
-            ["v4.5.RHBA-1234:4567.pre-1.2"],
+            ["v4.5-RHBA-1234-4567-pre-1.2"],
         ),
         IIBRes(
             "some-registry.com/index/image:v4.6",
             "some-registry.com/index/image@sha256:b2b2",
-            ["v4.6.RHBA-1234:4567.pre-1.2"],
+            ["v4.6-RHBA-1234-4567.pre-1.2"],
         ),
     ]
     mock_add_bundles.side_effect = iib_results
@@ -804,13 +804,13 @@ def test_push_operators_prerelease(
             "iib_result": iib_results[0],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "destination_tags": ["v4.5.RHBA-1234:4567.pre-1.2"],
+            "destination_tags": ["v4.5-pre-1.2-1234-4567"],
         },
         "v4.6": {
             "iib_result": iib_results[1],
             "signing_keys": ["some-key"],
             "is_hotfix": False,
-            "destination_tags": ["v4.6.RHBA-1234:4567.pre-1.2"],
+            "destination_tags": ["v4.6-pre-1.2-1234-4567"],
         },
     }
     expected_target_settings = target_settings.copy()
@@ -821,14 +821,14 @@ def test_push_operators_prerelease(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5.RHBA-1234:4567.pre-1.2", "v4.5-3"],
+        build_tags=["v4.5-3"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[1] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6.RHBA-1234:4567.pre-1.2", "v4.6-3"],
+        build_tags=["v4.6-3"],
         target_settings=expected_target_settings,
     )
 
@@ -839,7 +839,7 @@ def test_push_operators_prerelease(
         [
             mock.call(
                 "some-registry.com/index/image:v4.5",
-                ["quay.io/some-namespace/operators----index-image:v4.5.RHBA-1234:4567.pre-1.2"],
+                ["quay.io/some-namespace/operators----index-image:v4.5-pre-1.2-1234-4567"],
                 True,
                 target_settings,
             )
@@ -849,7 +849,7 @@ def test_push_operators_prerelease(
         [
             mock.call(
                 "some-registry.com/index/image:v4.6",
-                ["quay.io/some-namespace/operators----index-image:v4.6.RHBA-1234:4567.pre-1.2"],
+                ["quay.io/some-namespace/operators----index-image:v4.6-pre-1.2-1234-4567"],
                 True,
                 target_settings,
             )

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -1406,6 +1406,140 @@ def test_push_docker_full_success(
 @mock.patch("pubtools._quay.push_docker.PushDocker.get_docker_push_items")
 @mock.patch("pubtools._quay.push_docker.QuayClient")
 @mock.patch("pubtools._quay.push_docker.QuayApiClient")
+def test_push_docker_full_prerelease(
+    mock_quay_api_client,
+    mock_quay_client,
+    mock_get_docker_push_items,
+    mock_get_operator_push_items,
+    mock_check_repos_validity,
+    mock_generate_backup_mapping,
+    mock_container_image_pusher,
+    mock_container_signature_handler,
+    mock_operator_pusher,
+    mock_operator_signature_handler,
+    mock_rollback,
+    mock_timestamp,
+    target_settings,
+    container_multiarch_pre_release_push_item,
+    container_push_item_external_repos,
+    operator_push_item_ok,
+    fake_cert_key_paths,
+):
+    hub = mock.MagicMock()
+    mock_push_container_images = mock.MagicMock()
+    mock_container_image_pusher.return_value.push_container_images = mock_push_container_images
+
+    mock_sign_container_images = mock.MagicMock(return_value=[])
+    mock_container_signature_handler.return_value.sign_container_images = mock_sign_container_images
+
+    mock_sign_container_images_new_digests = mock.MagicMock(return_value=[])
+    mock_container_signature_handler.return_value.sign_container_images_new_digests = (
+        mock_sign_container_images_new_digests
+    )
+
+    mock_sign_operator_images = mock.MagicMock(return_value=[])
+    mock_container_signature_handler.return_value.sign_operator_images = mock_sign_operator_images
+
+    mock_push_index_images = mock.MagicMock()
+    mock_operator_pusher.return_value.push_index_images = mock_push_index_images
+
+    mock_get_signatures_from_pyxis = mock.MagicMock(
+        return_value=(
+            [
+                {
+                    "manifest_digest": "some-digest",
+                    "repository": "orig-ns/some-repo",
+                    "reference": "registry/orig-ns/some-repo:sometag",
+                    "_id": "signature-id-1",
+                }
+            ]
+        )
+    )
+    mock_container_signature_handler.return_value.get_signatures_from_pyxis = (
+        mock_get_signatures_from_pyxis
+    )
+    mock_build_index_images = mock.MagicMock()
+    mock_operator_pusher.return_value.build_index_images = mock_build_index_images
+
+    mock_push_index_images = mock.MagicMock()
+    mock_operator_pusher.return_value.push_index_images = mock_push_index_images
+
+    mock_operator_signature_handler.return_value.sign_operator_images = mock_sign_operator_images
+    mock_timestamp.return_value = "timestamp"
+
+    mock_get_docker_push_items.return_value = [container_multiarch_pre_release_push_item]
+    mock_get_operator_push_items.return_value = [operator_push_item_ok]
+    mock_generate_backup_mapping.return_value = (
+        {
+            push_docker.PushDocker.ImageData(
+                "some-ns/orig-ns----some-repo", "sometag", None, None
+            ): {"digest": "some-digest"},
+            push_docker.PushDocker.ImageData(
+                "some-ns/orig-ns----some-repo", "sometag2", None, None
+            ): {"manifests": [{"digest": "some-digest"}]},
+        },
+        ["item1", "item2"],
+    )
+    iib_result = mock.MagicMock(internal_index_image_copy_resolved="registry/ns/iib@digest")
+    mock_build_index_images.return_value = {"v4.5": {"iib_result": iib_result, "signing_keys": []}}
+
+    push_docker_instance = push_docker.PushDocker(
+        [container_multiarch_pre_release_push_item, operator_push_item_ok],
+        hub,
+        "1",
+        "some-target",
+        target_settings,
+    )
+    push_docker_instance.run()
+
+    mock_get_docker_push_items.assert_called_once_with()
+    mock_check_repos_validity.assert_called_once_with(
+        [container_multiarch_pre_release_push_item], hub, target_settings
+    )
+    mock_generate_backup_mapping.assert_called_once_with(
+        [container_multiarch_pre_release_push_item]
+    )
+    mock_container_image_pusher.assert_called_once_with(
+        [container_multiarch_pre_release_push_item], target_settings
+    )
+    mock_push_container_images.assert_called_once_with()
+    mock_container_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
+    assert mock_sign_container_images.call_count == 1
+    assert mock_sign_container_images.call_args_list[0] == mock.call(
+        [container_multiarch_pre_release_push_item]
+    )
+    assert mock_sign_container_images_new_digests.call_count == 1
+    assert mock_sign_container_images_new_digests.call_args_list[0] == mock.call(
+        [container_multiarch_pre_release_push_item]
+    )
+    mock_operator_pusher.assert_called_once_with([operator_push_item_ok], "1", target_settings)
+    mock_build_index_images.assert_called_once_with()
+    mock_push_index_images.assert_called_once_with(
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
+    )
+    mock_operator_signature_handler.assert_called_once_with(
+        hub, "1", target_settings, "some-target"
+    )
+    mock_sign_operator_images.assert_called_once_with(
+        {"v4.5": {"iib_result": iib_result, "signing_keys": []}}, "timestamp"
+    )
+    mock_rollback.assert_not_called()
+
+
+@mock.patch("pubtools._quay.push_docker.timestamp")
+@mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
+@mock.patch("pubtools._quay.push_docker.OperatorSignatureHandler")
+@mock.patch("pubtools._quay.push_docker.OperatorPusher")
+@mock.patch("pubtools._quay.push_docker.ContainerSignatureHandler")
+@mock.patch("pubtools._quay.push_docker.ContainerImagePusher")
+@mock.patch("pubtools._quay.push_docker.PushDocker.generate_backup_mapping")
+@mock.patch("pubtools._quay.push_docker.PushDocker.check_repos_validity")
+@mock.patch("pubtools._quay.push_docker.PushDocker.get_operator_push_items")
+@mock.patch("pubtools._quay.push_docker.PushDocker.get_docker_push_items")
+@mock.patch("pubtools._quay.push_docker.QuayClient")
+@mock.patch("pubtools._quay.push_docker.QuayApiClient")
 def test_push_docker_full_no_v2sch2(
     mock_quay_api_client,
     mock_quay_client,

--- a/tests/test_signature_handler.py
+++ b/tests/test_signature_handler.py
@@ -780,8 +780,8 @@ def test_sign_operator_images(
                 "registry1/iib-namespace/iib@sha256:a1a1a1",
                 ["v4.5-1"],
             ),
+            "destination_tags": ["v4.5"],
             "signing_keys": ["key1"],
-            "is_hotfix": False,
         },
         "v4.6": {
             "iib_result": IIBRes(
@@ -789,8 +789,8 @@ def test_sign_operator_images(
                 "registry1/iib-namespace/iib@sha256:b2b2b2",
                 ["v4.6-1"],
             ),
+            "destination_tags": ["v4.6"],
             "signing_keys": ["key2"],
-            "is_hotfix": False,
         },
     }
 
@@ -840,8 +840,7 @@ def test_sign_operator_images_hotfix(
                 ["v4.5-hotfixlabel-advid", "v4.5-stamp"],
             ),
             "signing_keys": ["betakey"],
-            "is_hotfix": True,
-            "hotfix_tag": "v4.5-hotfixlabel-advid",
+            "destination_tags": ["v4.5-hotfixlabel-advid"],
         },
     }
 
@@ -1082,7 +1081,7 @@ def test_sign_operator_images_no_signatures(
                 ["v4.5-1"],
             ),
             "signing_keys": [None],
-            "is_hotfix": False,
+            "destination_tags": ["v4.5"],
         },
     }
 


### PR DESCRIPTION
Containers with 'com.redhat.pre-release' label are released with different tags and to different index image (if they are also operators)