### PR TITLE
Unique task-id tags when pushing prerelease content

### DIFF
--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -655,7 +655,12 @@ class OperatorPusher:
                     image_repo=self.target_settings["iib_index_image"], tag=tag
                 )
                 build_tags = []
-                build_tags.append("{0}-{1}".format(index_image.split(":")[1], self.task_id))
+                if is_prerelease:
+                    build_tags.append(
+                        "{0}-{1}-{2}".format(index_image.split(":")[1], self.task_id, group)
+                    )
+                else:
+                    build_tags.append("{0}-{1}".format(index_image.split(":")[1], self.task_id))
 
                 bundles = [self.public_bundle_ref(i) for i in group_info["items"]]
                 signing_keys = sorted(

--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -657,7 +657,9 @@ class OperatorPusher:
                 build_tags = []
                 if is_prerelease:
                     build_tags.append(
-                        "{0}-{1}-{2}".format(index_image.split(":")[1], self.task_id, group)
+                        "{0}-{1}-{2}".format(
+                            index_image.split(":")[1], self.task_id, group.replace(":", "-")
+                        )
                     )
                 else:
                     build_tags.append("{0}-{1}".format(index_image.split(":")[1], self.task_id))

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -834,28 +834,28 @@ def test_push_operators_prerelease(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5-3"],
+        build_tags=["v4.5-3-RHBA-1234:4567-operator-name"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[1] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5-3"],
+        build_tags=["v4.5-3-RHBA-1234:4567-operator-name2"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[2] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6-3"],
+        build_tags=["v4.6-3-RHBA-1234:4567-operator-name"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[3] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6-3"],
+        build_tags=["v4.6-3-RHBA-1234:4567-operator-name2"],
         target_settings=expected_target_settings,
     )
 

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -834,28 +834,28 @@ def test_push_operators_prerelease(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5-3-RHBA-1234:4567-operator-name"],
+        build_tags=["v4.5-3-RHBA-1234-4567-operator-name"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[1] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.5",
         deprecation_list=["bundle1", "bundle2"],
-        build_tags=["v4.5-3-RHBA-1234:4567-operator-name2"],
+        build_tags=["v4.5-3-RHBA-1234-4567-operator-name2"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[2] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6-3-RHBA-1234:4567-operator-name"],
+        build_tags=["v4.6-3-RHBA-1234-4567-operator-name"],
         target_settings=expected_target_settings,
     )
     assert mock_add_bundles.call_args_list[3] == mock.call(
         bundles=["some-registry1.com/repo:1.0"],
         index_image="registry.com/rh-osbs/iib-pub-pending:v4.6",
         deprecation_list=["bundle3"],
-        build_tags=["v4.6-3-RHBA-1234:4567-operator-name2"],
+        build_tags=["v4.6-3-RHBA-1234-4567-operator-name2"],
         target_settings=expected_target_settings,
     )
 


### PR DESCRIPTION
Pubtools-quay call IIB to build index images with version + task-id to ensure there's preserved history of all builds requested by pub in IIB. For prerelease operators, as there's one build per operator, in the case of more operators it means same version + task-id tag is used for all of them.
That's why in the case of prerelease operators, also transformed advisory id is used