### PR TITLE
Pin pylint to workaround pylint bug

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 mock
 requests-mock
 pytest
+pylint<3.0.0
 pytest-pylint
 pytest-cov
 pubtools-pyxis


### PR DESCRIPTION
On Oct 2, 2023 pylint v3.0.0 released and after its release, the CI is failing with import error. Let's pin the pylint version to keep the CI working