### PR TITLE
Remove --skip-pulp argument when calling pubtools-iib

### DIFF
--- a/pubtools/_quay/operator_pusher.py
+++ b/pubtools/_quay/operator_pusher.py
@@ -242,9 +242,7 @@ class OperatorPusher:
         Returns (([str]), {str:str}):
             Tuple of arguments and environment variables to be used when calling pubtools-iib.
         """
-        args = ["--skip-pulp"]
-
-        args += ["--iib-server", target_settings["iib_server"]]
+        args = ["--iib-server", target_settings["iib_server"]]
         args += ["--iib-krb-principal", target_settings["iib_krb_principal"]]
 
         if target_settings.get("iib_overwrite_from_index", False):

--- a/tests/test_operator_pusher.py
+++ b/tests/test_operator_pusher.py
@@ -167,7 +167,6 @@ def test_iib_add_bundles_str_deprecation_list(
         ("pubtools-iib", "console_scripts", "pubtools-iib-add-bundles"),
         "pubtools-iib-add-bundles",
         [
-            "--skip-pulp",
             "--iib-server",
             "iib-server.com",
             "--iib-krb-principal",
@@ -233,7 +232,6 @@ def test_iib_add_bundles_list_deprecation_list(
         ("pubtools-iib", "console_scripts", "pubtools-iib-add-bundles"),
         "pubtools-iib-add-bundles",
         [
-            "--skip-pulp",
             "--iib-server",
             "iib-server.com",
             "--iib-krb-principal",
@@ -276,7 +274,6 @@ def test_iib_remove_operators(mock_run_entrypoint, target_settings, operator_pus
         ("pubtools-iib", "console_scripts", "pubtools-iib-remove-operators"),
         "pubtools-iib-remove-operators",
         [
-            "--skip-pulp",
             "--iib-server",
             "iib-server.com",
             "--iib-krb-principal",


### PR DESCRIPTION
As support for Docker Pulp has been removed from pubtools-iib, this argument is no longer a part of the library.

Refers to CLOUDDST-20283