### PR TITLE
Set AWS KMS credentials from target settings

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -19,6 +19,7 @@ from .utils.misc import (
     get_pyxis_ssl_paths,
     timestamp,
     pyxis_get_repo_metadata,
+    set_aws_kms_environment_variables,
 )
 
 # TODO: do we want this, or should I remove it?
@@ -713,6 +714,7 @@ class PushDocker:
 
         if self.target_settings.get("push_security_manifests_enabled", False):
             # Generate and push security manifests (if enabled in target settings)
+            set_aws_kms_environment_variables(self.target_settings, "security_manifest_signer")
             sec_manifest_pusher = SecurityManifestPusher(docker_push_items, self.target_settings)
             sec_manifest_pusher.push_security_manifests()
 

--- a/pubtools/_quay/utils/misc.py
+++ b/pubtools/_quay/utils/misc.py
@@ -421,3 +421,74 @@ def pyxis_get_repo_metadata(repo, target_settings):
         env_vars,
     )
     return metadata
+
+
+def set_aws_kms_environment_variables(target_settings, profile_name):
+    """
+    Set environment variables required to use an AWS KMS key.
+
+    The values are set from target settings based on the selected profile. Multiple profiles are
+    supported as multiple keys may be used during a push. Following env variables are set:
+    AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION. Missing data in target settings
+    will not result in an error. Target settings is expected to be in the following format:
+    {
+    "aws_kms_credentials": {
+        "profile-1": {
+            "aws_access_key_id": "id1",
+            "aws_secret_access_key": "key1",
+            "aws_default_region": "us-east-1"
+            },
+        "profile-2": {
+            "aws_access_key_id": "id2",
+            "aws_secret_access_key": "key2",
+            "aws_default_region": "us-east-2"
+            }
+        },
+    "other_target_setting":"data"
+    }
+
+    Args:
+        target_settings (dict):
+            Target settings.
+        profile_name (str):
+            Profile name whose credentials to apply.
+    """
+    if "aws_kms_credentials" not in target_settings:
+        LOG.warning(
+            "Target settings are missing the aws_kms_credentials property, "
+            "cannot set AWS KMS environment variables"
+        )
+        return
+    if profile_name not in target_settings["aws_kms_credentials"]:
+        LOG.warning(f"AWS KMS profile {profile_name} not found in the target settings")
+        return
+
+    if "aws_access_key_id" not in target_settings["aws_kms_credentials"][profile_name]:
+        LOG.warning(
+            "Cannot set AWS KMS environment variable AWS_ACCESS_KEY_ID, "
+            f"value missing in profile {profile_name}"
+        )
+    else:
+        os.environ["AWS_ACCESS_KEY_ID"] = target_settings["aws_kms_credentials"][profile_name][
+            "aws_access_key_id"
+        ]
+
+    if "aws_secret_access_key" not in target_settings["aws_kms_credentials"][profile_name]:
+        LOG.warning(
+            "Cannot set AWS KMS environment variable AWS_SECRET_ACCESS_KEY, "
+            f"value missing in profile {profile_name}"
+        )
+    else:
+        os.environ["AWS_SECRET_ACCESS_KEY"] = target_settings["aws_kms_credentials"][profile_name][
+            "aws_secret_access_key"
+        ]
+
+    if "aws_default_region" not in target_settings["aws_kms_credentials"][profile_name]:
+        LOG.warning(
+            "Cannot set AWS KMS environment variable AWS_DEFAULT_REGION, "
+            f"value missing in profile {profile_name}"
+        )
+    else:
+        os.environ["AWS_DEFAULT_REGION"] = target_settings["aws_kms_credentials"][profile_name][
+            "aws_default_region"
+        ]

--- a/tests/test_push_docker.py
+++ b/tests/test_push_docker.py
@@ -1262,6 +1262,7 @@ def test_rollback_delete_tag_server_error(
     mock_delete_tag.assert_called_once_with("some-namespace/target----repo3", "3")
 
 
+@mock.patch("pubtools._quay.push_docker.set_aws_kms_environment_variables")
 @mock.patch("pubtools._quay.push_docker.SecurityManifestPusher")
 @mock.patch("pubtools._quay.push_docker.timestamp")
 @mock.patch("pubtools._quay.push_docker.PushDocker.rollback")
@@ -1289,6 +1290,7 @@ def test_push_docker_full_success(
     mock_rollback,
     mock_timestamp,
     mock_security_manifest_pusher,
+    mock_set_aws_kms_environment_variables,
     target_settings,
     container_multiarch_push_item,
     container_push_item_external_repos,
@@ -1381,6 +1383,9 @@ def test_push_docker_full_success(
     assert mock_sign_container_images_new_digests.call_count == 1
     assert mock_sign_container_images_new_digests.call_args_list[0] == mock.call(
         [container_multiarch_push_item]
+    )
+    mock_set_aws_kms_environment_variables.assert_called_once_with(
+        target_settings, "security_manifest_signer"
     )
     mock_security_manifest_pusher.assert_called_once_with(
         [container_multiarch_push_item], target_settings


### PR DESCRIPTION
The environment variables enabling the access to AWS KMS key are set at runtime to values from target settings. The new function is expected to be called before using cosign is required. Multiple "profiles" are supported, so multiple keys can be used during the runtime of the task.