### PR TITLE
Fix a bug where 0 IIB builds cause a push to fail

### DIFF
--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -730,8 +730,10 @@ class PushDocker:
                 self.dest_operator_quay_client
             )
             if operator_pusher.ensure_bundles_present():
+                bundles_presence_check_failed = False
                 iib_results = operator_pusher.build_index_images()
             else:
+                bundles_presence_check_failed = True
                 iib_results = {}
             # Sign operator images
 
@@ -748,7 +750,11 @@ class PushDocker:
                 operator_pusher.push_index_images(successful_iib_results, index_stamp)
 
             # Rollback only when all index image builds fails or there are failed items
-            if not any([x["iib_result"] for x in iib_results.values()]) or failed_items:
+            # Empty iib_results is not an error and shouldn't fail the push. The only exception is
+            # when bundles presence check failed.
+            if (iib_results or bundles_presence_check_failed) and (
+                not any([x["iib_result"] for x in iib_results.values()]) or failed_items
+            ):
                 if failed_items:
                     LOG.error("There are failed push items. Cannot continue, running rollback.")
                 else:


### PR DESCRIPTION
Empty iib_results is evaluated as an error and causes a rollback. However, for RHTAP pushes IIB is called 0 times and only bundle pushing is required. Fix the condition so that the push succeeds with 0 IIB builds.

Refers to CLOUDDST-21307