### PR TITLE
Split signers to prepush and non prepush

### DIFF
--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -161,6 +161,7 @@ def _sign_index_image(
         signing_keys (list): List of signing keys.
         task_id (str): Task ID.
         target_settings (dict): Target settings.
+        pre_push (bool): Whether to sign before push.
     Returns:
         list: List of current signatures.
     """
@@ -170,18 +171,8 @@ def _sign_index_image(
     current_signatures: list[tuple[str, str, str]] = [
         (e.reference, e.digest, e.signing_key) for e in to_sign_entries
     ]
-    if pre_push:
-
-        def pre_push_test(x: bool) -> bool:
-            return x
-
-    else:
-
-        def pre_push_test(x: bool) -> bool:
-            return not x
-
     for signer in target_settings["signing"]:
-        if signer["enabled"] and pre_push_test(SIGNER_BY_LABEL[signer["label"]].pre_push):
+        if signer["enabled"] and SIGNER_BY_LABEL[signer["label"]].pre_push == pre_push:
             signercls = SIGNER_BY_LABEL[signer["label"]]
             signer = signercls(config_file=signer["config_file"], settings=target_settings)
             signer.sign_containers(to_sign_entries, task_id=task_id)

--- a/pubtools/_quay/iib_operations.py
+++ b/pubtools/_quay/iib_operations.py
@@ -171,9 +171,14 @@ def _sign_index_image(
         (e.reference, e.digest, e.signing_key) for e in to_sign_entries
     ]
     if pre_push:
-        pre_push_test = lambda x: x
+
+        def pre_push_test(x: bool) -> bool:
+            return x
+
     else:
-        pre_push_test  = lambda x: not x
+
+        def pre_push_test(x: bool) -> bool:
+            return not x
 
     for signer in target_settings["signing"]:
         if signer["enabled"] and pre_push_test(SIGNER_BY_LABEL[signer["label"]].pre_push):

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -681,7 +681,7 @@ class PushDocker:
                         iib_details["signing_keys"],
                         self.task_id,
                         self.target_settings,
-                        pre_push=True
+                        pre_push=True,
                     )
                 )
 
@@ -710,7 +710,7 @@ class PushDocker:
                         iib_details["signing_keys"],
                         self.task_id,
                         self.target_settings,
-                        pre_push=False
+                        pre_push=False,
                     )
                 )
 

--- a/pubtools/_quay/push_docker.py
+++ b/pubtools/_quay/push_docker.py
@@ -570,7 +570,7 @@ class PushDocker:
         - Add operator bundles to index images by using IIB
         - Sign index images using RADAS and upload signatures to Pyxis
         - Push the index images to Quay
-        - Remove outdated container signaturespush
+        - Remove outdated container signatures
         - (in case of failure) Rollback destination repos to the pre-push state
         """
         # TODO: Do we need to manage push item state?

--- a/pubtools/_quay/signer_wrapper.py
+++ b/pubtools/_quay/signer_wrapper.py
@@ -38,6 +38,7 @@ class SignerWrapper:
     """Wrapper providing functionality to sign containers with a generic signer."""
 
     label = "unused"
+    pre_push = False
 
     SCHEMA: type[Schema] = NoSchema
     entry_point_conf = ["signer", "group", "signer"]
@@ -165,6 +166,8 @@ class MsgSignerWrapper(SignerWrapper):
     """Wrapper for messaging signer functionality."""
 
     label = "msg_signer"
+    pre_push = True
+
     entry_point_conf = ["pubtools-sign", "modules", "pubtools-sign-msg-container-sign"]
 
     MAX_MANIFEST_DIGESTS_PER_SEARCH_REQUEST = 50
@@ -378,6 +381,8 @@ class CosignSignerWrapper(SignerWrapper):
     """Wrapper for cosign signer functionality."""
 
     label = "cosign_signer"
+    pre_push = False
+
     entry_point_conf = ["pubtools-sign", "modules", "pubtools-sign-cosign-container-sign"]
 
     SCHEMA = CosignSignerSettingsSchema

--- a/pubtools/_quay/tag_docker.py
+++ b/pubtools/_quay/tag_docker.py
@@ -516,8 +516,10 @@ class TagDocker:
         if not details:
             raise BadPushItem("Source image must be specified if add operation was requested")
         registries = self.target_settings["docker_settings"]["docker_reference_registry"]
+        if details.manifest_type == TagDocker.MANIFEST_LIST_TYPE:
+            raise ValueError("Tagging workflow is not supported for multiarch images")
 
-        if details.manifest_type == TagDocker.MANIFEST_V2S2_TYPE and push_item.claims_signing_key:
+        if push_item.claims_signing_key:
             for registry in registries:
                 reference = external_image_schema.format(
                     host=registry, repo=list(push_item.repos.keys())[0], tag=tag
@@ -547,20 +549,27 @@ class TagDocker:
                     continue
                 outdated_manifests.append((mad.digest, tag, repo))
 
-            for signer in self.target_settings["signing"]:
-                if signer["enabled"]:
-                    signercls = SIGNER_BY_LABEL[signer["label"]]
+            for _signer in self.target_settings["signing"]:
+                if _signer["enabled"]:
+                    signercls = SIGNER_BY_LABEL[_signer["label"]]
                     signer = signercls(
-                        config_file=signer["config_file"], settings=self.target_settings
+                        config_file=_signer["config_file"], settings=self.target_settings
                     )
                     # exclude should be bool, and outdated manifests should be list?
                     signer.remove_signatures(outdated_manifests, _exclude=current_signatures)
-                    signer.sign_containers(to_sign_entries, task_id=self.task_id)
-
-        elif details.manifest_type == TagDocker.MANIFEST_LIST_TYPE:
-            raise ValueError("Tagging workflow is not supported for multiarch images")
+                    if SIGNER_BY_LABEL[_signer["label"]].pre_push:
+                        signer.sign_containers(to_sign_entries, task_id=self.task_id)
 
         ContainerImagePusher.run_tag_images(source_image, [dest_image], True, self.target_settings)
+
+        if push_item.claims_signing_key:
+            for _signer in self.target_settings["signing"]:
+                if _signer["enabled"] and not SIGNER_BY_LABEL[_signer["label"]].pre_push:
+                    signercls = SIGNER_BY_LABEL[_signer["label"]]
+                    signer = signercls(
+                        config_file=_signer["config_file"], settings=self.target_settings
+                    )
+                    signer.sign_containers(to_sign_entries, task_id=self.task_id)
 
     def merge_manifest_lists_sign_images(
         self, push_item: Any, tag: str, add_archs: list[str]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -125,7 +125,7 @@ def test_push_docker_multiarch_merge_ml_operator(
             {
                 "_id": 1,
                 "manifest_digest": "sha256:6666666666",
-                "reference": "some-registry1.com/namespace/operators/index-image:v4.5",
+                "reference": "some-registry2.com/namespace/operators/index-image:v4.5",
                 "sig_key_id": "some-key",
                 "repository": "operators/index-image",
             }
@@ -143,7 +143,7 @@ def test_push_docker_multiarch_merge_ml_operator(
             {
                 "_id": 1,
                 "manifest_digest": "sha256:6666666666",
-                "reference": "some-registry1.com/namespace/operators/index-image:v4.6",
+                "reference": "some-registry2.com/namespace/operators/index-image:v4.6",
                 "sig_key_id": "some-key",
                 "repository": "operators/index-image",
             }
@@ -290,38 +290,6 @@ def test_push_docker_multiarch_merge_ml_operator(
                     config_file="test-config.yml",
                     signing_key="some-key",
                     reference="some-registry2.com/namespace/operators/index-image:v4.5",
-                    digest="sha256:5555555555",
-                    task_id="1",
-                    repo="operators/index-image",
-                ),
-                mock.call(
-                    config_file="test-config.yml",
-                    signing_key="some-key",
-                    reference="some-registry1.com/namespace/operators/index-image:v4.5",
-                    digest="sha256:5555555555",
-                    task_id="1",
-                    repo="operators/index-image",
-                ),
-                mock.call(
-                    config_file="test-config.yml",
-                    signing_key="some-key",
-                    reference="some-registry2.com/namespace/operators/index-image:v4.5",
-                    digest="sha256:5555555555",
-                    task_id="1",
-                    repo="operators/index-image",
-                ),
-                mock.call(
-                    config_file="test-config.yml",
-                    signing_key="some-key",
-                    reference="some-registry1.com/namespace/operators/index-image:v4.6",
-                    digest="sha256:5555555555",
-                    task_id="1",
-                    repo="operators/index-image",
-                ),
-                mock.call(
-                    config_file="test-config.yml",
-                    signing_key="some-key",
-                    reference="some-registry2.com/namespace/operators/index-image:v4.6",
                     digest="sha256:5555555555",
                     task_id="1",
                     repo="operators/index-image",


### PR DESCRIPTION
Cosign signer cannot work without image being available in destination registry. Therefore signer wrappers now have attribute pre_push which indicates if signer should run before container push stage and which after