### PR TITLE
Add option to disable sending transparency logs to rekor

### DIFF
--- a/pubtools/_quay/command_executor.py
+++ b/pubtools/_quay/command_executor.py
@@ -243,9 +243,9 @@ class RemoteExecutor(Executor):
         self.key_filename = key_filename
         self.password = password
         if accept_unknown_host:
-            self.missing_host_policy: paramiko.client.WarningPolicy | paramiko.client.RejectPolicy = (  # noqa: E501
-                paramiko.client.WarningPolicy()
-            )
+            self.missing_host_policy: (
+                paramiko.client.WarningPolicy | paramiko.client.RejectPolicy
+            ) = paramiko.client.WarningPolicy()  # noqa: E501
         else:
             self.missing_host_policy = paramiko.client.RejectPolicy()
         self.port = port if port else 22

--- a/pubtools/_quay/security_manifest_pusher.py
+++ b/pubtools/_quay/security_manifest_pusher.py
@@ -97,7 +97,11 @@ class SecurityManifestPusher:
         return True
 
     def cosign_get_existing_attestation(
-        self, image_ref: str, output_file: str, rekor_url: str | None = None
+        self,
+        image_ref: str,
+        output_file: str,
+        rekor_url: str | None = None,
+        skip_verify_rekor: bool = False,
     ) -> bool:
         """
         Use cosign to verify and get an attestation, if it exists.
@@ -109,6 +113,10 @@ class SecurityManifestPusher:
                 File where to save the attestation.
             rekor_url (str):
                 URL of the rekor instance to use. If unset, default will be used.
+            skip_verify_rekor (bool):
+                Whether to skip rekor log verification. This option is recommended for when an
+                attestation was created without uploading a transparency log to rekor. rekor_url
+                parameter is ignored if this option is enabled.
         Returns (bool):
             Whether the attestation was gathered successfully (True) or not (False).
         """
@@ -121,7 +129,9 @@ class SecurityManifestPusher:
             "--output-file",
             output_file,
         ]
-        if rekor_url:
+        if skip_verify_rekor:
+            cmd.insert(2, "--insecure-ignore-tlog=true")
+        elif rekor_url:
             cmd.insert(2, f"--rekor-url={rekor_url}")
         LOG.info(f"Running command '{' '.join(cmd)}'")
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
@@ -133,7 +143,11 @@ class SecurityManifestPusher:
         return True
 
     def cosign_attest_security_manifest(
-        self, security_manifest_path: str, image_ref: str, rekor_url: str | None = None
+        self,
+        security_manifest_path: str,
+        image_ref: str,
+        rekor_url: str | None = None,
+        skip_upload_rekor: bool = False,
     ) -> None:
         """
         Use cosign to attest a security manifest and push the created image to the destination.
@@ -145,6 +159,9 @@ class SecurityManifestPusher:
                 Image to which the security manifest should be attested to.
             rekor_url (str):
                 URL of the rekor instance to use. If unset, default will be used.
+            skip_upload_rekor (bool):
+                Whether to skip uploading transparency log to rekor. rekor_url parameter is ignored
+                if this option is enabled.
         Raises:
             RuntimeError:
                 If the command fails.
@@ -159,7 +176,9 @@ class SecurityManifestPusher:
             "-y",
             image_ref,
         ]
-        if rekor_url:
+        if skip_upload_rekor:
+            cmd.insert(2, "--tlog-upload=false")
+        elif rekor_url:
             cmd.insert(2, f"--rekor-url={rekor_url}")
         LOG.info(f"Running command '{' '.join(cmd)}'")
         result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
@@ -370,7 +389,10 @@ class SecurityManifestPusher:
             image_ref = f"{repo}@{image_manifest.digest}"
             attestation_file = os.path.join(dir_path, f"attestation_{uuid.uuid4().hex}.json")
             attestation_exist = self.cosign_get_existing_attestation(
-                image_ref, attestation_file, self.target_settings.get("cosign_rekor_url", None)
+                image_ref,
+                attestation_file,
+                self.target_settings.get("cosign_rekor_url", None),
+                self.target_settings.get("cosign_sbom_skip_verify_rekor", False),
             )
 
             if attestation_exist:
@@ -411,6 +433,7 @@ class SecurityManifestPusher:
                 full_security_manifest_path,
                 image_ref,
                 self.target_settings.get("cosign_rekor_url", None),
+                self.target_settings.get("cosign_sbom_skip_upload_rekor", False),
             )
 
     def get_source_item_security_manifests(

--- a/pubtools/_quay/tag_images.py
+++ b/pubtools/_quay/tag_images.py
@@ -258,9 +258,11 @@ def tag_images(
 
     if remote_exec:
         accept_host = not ssh_reject_unknown_host if ssh_reject_unknown_host else True
-        executor_class: functools.partial[RemoteExecutor] | functools.partial[
-            ContainerExecutor
-        ] | functools.partial[LocalExecutor] = functools.partial(
+        executor_class: (
+            functools.partial[RemoteExecutor]
+            | functools.partial[ContainerExecutor]
+            | functools.partial[LocalExecutor]
+        ) = functools.partial(
             RemoteExecutor,
             ssh_remote_host,
             ssh_username,

--- a/tests/test_image_untagger.py
+++ b/tests/test_image_untagger.py
@@ -43,9 +43,11 @@ def register_manifest_url(mocker, repo, manifest, data, mlist=False):
     mocker.get(
         "https://stage.quay.io/v2/name/%s/manifests/%s" % (repo, manifest),
         text=json.dumps(data, sort_keys=True),
-        headers={"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"}
-        if mlist
-        else {"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"},
+        headers=(
+            {"Content-Type": "application/vnd.docker.distribution.manifest.list.v2+json"}
+            if mlist
+            else {"Content-Type": "application/vnd.docker.distribution.manifest.v2+json"}
+        ),
     )
 
 


### PR DESCRIPTION
Currently, if custom rekor URL is not provided, cosign uses public rekor instance by default. This is not desirable, as cosign shouldn't send logs to any rekor instance until a private instance is created. Add an option toggleable through target settings to disable sending and checking rekor logs for SBOMs. Different settings are used to control sending and checking, because some SBOMs will be created without using rekor, and thus their logs won't exist even after a private instance has been created. These images may still need to be accessed even after private rekor instance is created.

Refers to CLOUDDST-21813