### PR TITLE
Bump version to 0.16.0

### DIFF
--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+0.16.0 (2024-02-08)
+-------------------
+
+* Instrument tracing for container push
+* Add option to disable sending transparency logs to rekor
+
 0.15.0 (2023-12-07)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if os.environ.get("READTHEDOCS", None):
 
 setup(
     name="pubtools-quay",
-    version="0.15.0",
+    version="0.16.0",
     description="Pubtools-quay",
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Though this commit will not be tagged or released (the 0.16.0 release is in another branch), the latest version should be in the main branch as well.