### PR TITLE
Bump version to 0.17.0

### DIFF
--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -1,6 +1,12 @@
 ChangeLog
 =========
 
+0.17.0 (2024-02-27)
+------------------
+
+* Should not call IIB if bundle is opted in fbc and targets OCP >=4.11
+
+
 0.16.0 (2024-02-08)
 -------------------
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if os.environ.get("READTHEDOCS", None):
 
 setup(
     name="pubtools-quay",
-    version="0.16.0",
+    version="0.17.0",
     description="Pubtools-quay",
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Though this commit will not be tagged or released (the 0.17.0 release is in another branch), the latest version should be in the main branch as well.