### PR TITLE
Skip creating ML SBOM if there are no arch SBOMs

### DIFF
--- a/pubtools/_quay/security_manifest_pusher.py
+++ b/pubtools/_quay/security_manifest_pusher.py
@@ -660,7 +660,7 @@ class SecurityManifestPusher:
                     item, digest_manifest, destination_repos, tmp_dir
                 )
 
-            if is_multiach_image:
+            if is_multiach_image and digest_manifests:
                 self.push_manifest_list_security_manifests(item, tmp_dir)
 
     @log_step("Push container security manifests")


### PR DESCRIPTION
It's possible that older images won't have SBOMs. Skip creating ML SBOMs in this scenario to prevent an error from being raised.

Refers to CLOUDDST-22016