### PR TITLE
Bump version to 0.18.0

### DIFF
--- a/docs/source/CHANGELOG.rst
+++ b/docs/source/CHANGELOG.rst
@@ -1,6 +1,11 @@
 ChangeLog
 =========
 
+0.18.0 (2024-03-18)
+-------------------
+
+* Generate SBOM attestations for manifest lists
+
 0.17.0 (2024-02-27)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ if os.environ.get("READTHEDOCS", None):
 
 setup(
     name="pubtools-quay",
-    version="0.17.0",
+    version="0.18.0",
     description="Pubtools-quay",
     long_description=long_description,
     long_description_content_type="text/x-rst",


### PR DESCRIPTION
Though this commit will not be tagged or released (the 0.18.0 release is in another branch), the latest version should be in the main branch as well.