### PR TITLE
Do not remove cosign signatures in remove and clear repo

### DIFF
--- a/pubtools/_quay/clear_repo.py
+++ b/pubtools/_quay/clear_repo.py
@@ -138,6 +138,8 @@ def clear_repositories(repositories: str, settings: dict[str, Any]) -> None:
 
     for n, signer in enumerate(signers):
         signercls = SIGNER_BY_LABEL[signer]
+        if not signercls.pre_push:
+            continue
         _signer = signercls(config_file=signer_configs[n], settings=settings)
         _signer.remove_signatures(outdated_manifests, _exclude=[])
 

--- a/pubtools/_quay/remove_repo.py
+++ b/pubtools/_quay/remove_repo.py
@@ -143,6 +143,8 @@ def remove_repositories(repositories: str, settings: dict[str, Any]) -> None:
 
     for n, signer in enumerate(signers):
         signercls = SIGNER_BY_LABEL[signer]
+        if not signercls.pre_push:
+            continue
         signer = signercls(config_file=signer_configs[0], settings=signer_settings)
         signer.remove_signatures(outdated_manifests, _exclude=[])
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1501,8 +1501,8 @@ def test_clear_repo(
                 pyxis_ssl_crtfile="/path/to/file.crt",
                 pyxis_ssl_keyfile="/path/to/file.key",
                 pyxis_request_threads=7,
-                signers="msg_signer",
-                signer_configs="/test-config.yml",
+                signers="msg_signer,cosign_signer",
+                signer_configs="/test-config.yml,/test-config.yml",
             ),
         )
         signer_wrapper_remove_signatures.assert_called_with([1])
@@ -1580,8 +1580,8 @@ def test_remove_repo(
                 pyxis_ssl_crtfile="/path/to/file.crt",
                 pyxis_ssl_keyfile="/path/to/file.key",
                 pyxis_request_threads=7,
-                signers="msg_signer",
-                signer_configs="/test_config.yml",
+                signers="msg_signer,cosign_signer",
+                signer_configs="/test_config.yml,/test_config.yml",
             ),
         )
         signer_wrapper_remove_signatures.assert_called_with([1])


### PR DESCRIPTION
In both remove an clear repo operations, all tags are cleared. Therefore there's not need to explicitly remove cosign signatures which are stored as special tags