### PR TITLE
Fix SBOM pushing in ML merge workflow and remove field from SBOM

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -101,7 +101,8 @@ jobs:
         run: tox -e py311
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.6
-        env: CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true
           verbose: true


### PR DESCRIPTION
This commit fixes two issues.

Firstly, ML merging workflow can cause the SBOM pushing to raise an error in some cases. It happens when an old arch that doesn't have an SBOM is merged with new archs. Pubtools-quay attempts to find all arch SBOMs so that it can re-publish them for the ML digest. However, it cannot find an SBOM of the old arch, raising an error. The bug can be fixed by removing the error and tolerating that the ML SBOM will not contain SBOMs of every image arch.

Secondly, each generated SBOM contains the "incompleteness_reasons" field, which is not a part of the CycloneDX spec and exists for internal use only. Remove this field from the SBOMs before publishing them to the final repos.

Refers to:
CLOUDDST-22748
CLOUDDST-22739