### PR TITLE
Raise an error when manifest claims retry limit is reached

### DIFF
--- a/pubtools/_quay/manifest_claims_handler.py
+++ b/pubtools/_quay/manifest_claims_handler.py
@@ -408,8 +408,9 @@ class _ManifestClaimsRunner(object):
         LOG.error("Error in message handler: %s", error)
 
         if self._retry_attempts > self._maximum_retries:
-            LOG.warning("Retry limit reached. Messaging will not be restarted!")
-            return
+            raise RuntimeError(
+                f"Retry limit reached. Message handler has failed with an error: {error}"
+            )
 
         missing = [
             msg for msg in self._claim_messages if msg["request_id"] not in self._received_messages

--- a/tests/test_manifestclaimshandler.py
+++ b/tests/test_manifestclaimshandler.py
@@ -315,14 +315,14 @@ def test_manifest_claims_runner_no_more_retries(runner, debug_logs):
     runtime_error_message = "Runtime error message"
     exception = RuntimeError(runtime_error_message)
 
-    runner.on_error(exception)
+    with pytest.raises(RuntimeError, match="Retry limit reached\. Message handler has failed .*"):
+        runner.on_error(exception)
 
     runner._run.assert_not_called()
 
     logs = debug_logs.text
     check_strings = [
         "Error in message handler: {0}".format(exception),
-        "Retry limit reached. Messaging will not be restarted!",
     ]
     for string in check_strings:
         assert_that(logs, contains_string(string))


### PR DESCRIPTION
ManifestClaimsHandler automatically retries when a message encounters an error. However, when a retry limit is reached, the handler doesn't raise an error and simply continues the push with missing messages. This is obviously an issue as it results in some signatures not being created in the push. Fix the issue by raising an error when the retry limit is reached.

NOTE: At the time of writing this fix, the affected code is no longer used in production, and is superseded by pubtools-sign. The fix is implemented only if a rollback to the old code was necessary.

Refers to CLOUDDST-22737