### PR TITLE
Fix SBOM-related issues

### DIFF
--- a/pubtools/_quay/quay_api_client.py
+++ b/pubtools/_quay/quay_api_client.py
@@ -42,11 +42,10 @@ class QuayApiClient:
         response = self.session.delete(endpoint)
 
         # Tag not existing is a tolerable error
-        if "Invalid repository tag" not in response.text:
-            response.raise_for_status()
-        else:
+        if response.status_code == 404:
             LOG.warning("Tag '{0}' already doesn't exist in repo '{1}'".format(tag, repository))
-
+        else:
+            response.raise_for_status()
         return response
 
     def delete_repository(self, repository: str) -> requests.Response:

--- a/tests/test_quay_api_client.py
+++ b/tests/test_quay_api_client.py
@@ -24,7 +24,7 @@ def test_delete_client():
             [
                 {"text": "Unauthorized", "status_code": 401},
                 {"text": "Success", "status_code": 200},
-                {"text": "Invalid repository tag 10", "status_code": 400},
+                {"text": "Not found", "status_code": 404},
             ],
         )
         with pytest.raises(requests.HTTPError, match="401 Client Error.*"):
@@ -33,8 +33,8 @@ def test_delete_client():
         resp = client.delete_tag("some-repo", "10")
         assert resp.status_code == 200
         resp = client.delete_tag("some-repo", "10")
-        assert resp.text == "Invalid repository tag 10"
-        assert resp.status_code == 400
+        assert resp.text == "Not found"
+        assert resp.status_code == 404
 
         assert m.call_count == 3
 


### PR DESCRIPTION
This commit fixes 3 issues:
- ML atestations are double encoded - they need to be decoded twice before SBOM content can be accessed. This is because ML attestation uses arch attestations as an input, when it should be using SBOMs instead. Fix the issue by extracting the SBOMs from arch attestations before attesting them to the manifest list.
- Quay API delete tag raises a 404 error, which is incorrect. While the original implementation tries to supress the error, the changes in Quay API made the solution no longer work. This operation is used in the SBOM workflow, which is likely why we encountered this error after such a long time. Fix the condition to suppress a 404 error.
- cosign attest command can fail due to transient networking issues. Increase the push stability by implementing retries to this command.

Refers to CLOUDDST-23117, CLOUDDST-23118, CLOUDDST-23119