### PR TITLE
Fix manifest list digest in tag docker [CLOUDDST-24102]

### DIFF
--- a/src/pubtools/_quay/tag_docker.py
+++ b/src/pubtools/_quay/tag_docker.py
@@ -15,7 +15,6 @@ from .exceptions import (
 )
 from .utils.misc import (
     get_internal_container_repo_name,
-    get_pyxis_ssl_paths,
     set_aws_kms_environment_variables,
 )
 from .quay_client import QuayClient
@@ -510,8 +509,6 @@ class TagDocker:
                 Push item to perform the workflow with.
             tag (str):
                 Tag, which acts as a destination to the copy operation.
-            signature_handler (BasicSignatureHandler):
-                Instance of signature handler which will perform the signing.
             executor (Executor):
                 Instance of Executor subclass used for skopeo inspect.
         """
@@ -573,7 +570,6 @@ class TagDocker:
                     )
                 )
 
-            cert, key = get_pyxis_ssl_paths(self.target_settings)
             item_processor = item_processor_for_internal_data(
                 self.quay_client,
                 self.target_settings["quay_host"].rstrip("/"),
@@ -634,8 +630,6 @@ class TagDocker:
                 Tag, which acts as a destination to the merge operation.
             add_archs ([str]):
                 Architectures which should be copied to the existing manifest list.
-            signature_handler (BasicSignatureHandler):
-                Instance of signature handler which will perform the signing.
         """
         LOG.info(
             "Architectures {0} of tag '{1}' will be copied to destination tag '{2}'".format(
@@ -699,7 +693,6 @@ class TagDocker:
                         (reference, manifest["digest"], push_item.claims_signing_key)
                     )
 
-            namespace = self.target_settings["quay_namespace"]
             item_processor = item_processor_for_internal_data(
                 self.quay_client,
                 self.target_settings["quay_host"].rstrip("/"),
@@ -748,7 +741,7 @@ class TagDocker:
             ml_to_sign = raw_src_manifest
             self.quay_client.upload_manifest(raw_src_manifest, dest_image, raw=True)
         else:
-            ml_to_sign = json.dumps(new_manifest_list)
+            ml_to_sign = json.dumps(new_manifest_list, sort_keys=True, indent=4)
             self.quay_client.upload_manifest(new_manifest_list, dest_image)
 
         if push_item.claims_signing_key:
@@ -836,8 +829,6 @@ class TagDocker:
             host=self.quay_host, namespace=namespace, repo=internal_repo
         )
         dest_image = "{0}:{1}".format(full_repo, tag)
-
-        cert, key = get_pyxis_ssl_paths(self.target_settings)
 
         for signer in self.target_settings["signing"]:
             if signer["enabled"]:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -946,8 +946,8 @@ def test_tag_docker_multiarch_merge_ml(
                         "sha256:1111111111",
                         "sha256:5555555555",
                         "sha256:5555555555",
-                        "sha256:71e75d5344d529631eaf40a8f9522edb7a66620d73eda6aff667572d511c6519",
-                        "sha256:71e75d5344d529631eaf40a8f9522edb7a66620d73eda6aff667572d511c6519",
+                        "sha256:5fd7b41b6f2af60c0dd393623acd01a7010eebbea85a525137cb5de35d19b8e8",
+                        "sha256:5fd7b41b6f2af60c0dd393623acd01a7010eebbea85a525137cb5de35d19b8e8",
                     ],
                     identity=[
                         "some-registry1.com/namespace/test_repo:v1.6",


### PR DESCRIPTION
Manifest list to be signed should be the same as the one to be uploaded. It also cleaned up some unused variables and docstrings.