### PR TITLE
Support tagging OCI images [CLOUDDST-24638]

### DIFF
--- a/src/pubtools/_quay/command_executor.py
+++ b/src/pubtools/_quay/command_executor.py
@@ -118,9 +118,9 @@ class Executor(object):
                 Whether to copy all architectures (if multiarch image)
         """
         if all_arch:
-            cmd = "skopeo copy --all docker://{0} docker://{1} --format v2s2"
+            cmd = "skopeo copy --all docker://{0} docker://{1}"
         else:
-            cmd = "skopeo copy docker://{0} docker://{1} --format v2s2"
+            cmd = "skopeo copy docker://{0} docker://{1}"
 
         for dest_ref in dest_refs:
             LOG.info("Tagging source '{0}' to destination '{1}'".format(source_ref, dest_ref))

--- a/src/pubtools/_quay/manifest_list_merger.py
+++ b/src/pubtools/_quay/manifest_list_merger.py
@@ -171,20 +171,13 @@ class ManifestListMerger:
         if not self._src_quay_client or not self._dest_quay_client:
             raise RuntimeError("QuayClient instance must be set for both source and dest images")
 
-        src_manifest_list = cast(
-            ManifestList,
-            self._src_quay_client.get_manifest(
-                self.src_image, media_type=QuayClient.MANIFEST_LIST_TYPE
-            ),
-        )
+        src_manifest_list = cast(ManifestList, self._src_quay_client.get_manifest(self.src_image))
         # It's possible that destination doesn't exist in this workflow. ML merging logic is still
         # necessary due to only some archs being eligible
         try:
             dest_manifest_list = cast(
                 ManifestList,
-                self._dest_quay_client.get_manifest(
-                    self.dest_image, media_type=QuayClient.MANIFEST_LIST_TYPE
-                ),
+                self._dest_quay_client.get_manifest(self.dest_image),
             )
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404 or e.response.status_code == 401:

--- a/tests/test_command_executor.py
+++ b/tests/test_command_executor.py
@@ -749,12 +749,8 @@ def test_skopeo_tag_images(mock_run_cmd):
 
     executor.tag_images("quay.io/repo/image:1", ["quay.io/repo/dest:1", "quay.io/repo/dest:2"])
     assert mock_run_cmd.call_args_list == [
-        mock.call(
-            "skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1 --format v2s2"
-        ),
-        mock.call(
-            "skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2 --format v2s2"
-        ),
+        mock.call("skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"),
+        mock.call("skopeo copy docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"),
     ]
 
 
@@ -766,14 +762,8 @@ def test_skopeo_tag_images_all_arch(mock_run_cmd):
         "quay.io/repo/image:1", ["quay.io/repo/dest:1", "quay.io/repo/dest:2"], True
     )
     assert mock_run_cmd.call_args_list == [
-        mock.call(
-            "skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"
-            " --format v2s2"
-        ),
-        mock.call(
-            "skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"
-            " --format v2s2"
-        ),
+        mock.call("skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:1"),
+        mock.call("skopeo copy --all docker://quay.io/repo/image:1 docker://quay.io/repo/dest:2"),
     ]
 
 

--- a/tests/test_tag_docker.py
+++ b/tests/test_tag_docker.py
@@ -2161,7 +2161,6 @@ def test_manifest_list_remove_archs(
 
     mock_get_manifest.assert_called_once_with(
         "quay.io/some-namespace/namespace----test_repo2:v1.8",
-        media_type=mock_quay_client.MANIFEST_LIST_TYPE,
     )
     mock_upload_manifest.assert_called_once_with(
         expected_manifest_list, "quay.io/some-namespace/namespace----test_repo2:v1.8"


### PR DESCRIPTION
Remove format in skopeo copy so that destination can be oci image, manifest type of source is the default format.